### PR TITLE
Add callback to kill

### DIFF
--- a/test/ngrok.spec.js
+++ b/test/ngrok.spec.js
@@ -57,8 +57,8 @@ describe('starting simple local server', function() {
 
 				describe('disconnecting from ngrok', function () {
 
-					before(function() {
-						ngrok.disconnect();
+					before(function(done) {
+						ngrok.disconnect(done);
 					});
 
 					describe('calling local server through discconected ngrok', function() {


### PR DESCRIPTION
Pretty sure tests pass due to some race (mocha may wait between setup/tests) for disconnect... I am using this to ensure that ngrok gets cleaned up during SIGTERM.
