### PR TITLE
Export emitter for node v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - "4.0.0"
   - "0.12"
   - "0.11"
 os:

--- a/index.js
+++ b/index.js
@@ -204,15 +204,9 @@ function kill(cb) {
 	return ngrok.kill();
 }
 
-var exports = {
-	connect: connect,
-	disconnect: disconnect,
-	authtoken: authtoken,
-	kill: kill
-};
+emitter.connect = connect;
+emitter.disconnect = disconnect;
+emitter.authtoken = authtoken;
+emitter.kill = kill;
 
-for (var key in emitter) {
-	exports[key] = emitter[key];
-}
-
-module.exports = exports;
+module.exports = emitter;


### PR DESCRIPTION
This PR will fix errors on https://github.com/bubenshchykov/ngrok/pull/37 (node v4) .

We have to export `emitter` object rather than copying it since `emit` method doesn't work if EventEmitter reset `_events` property.