### PR TITLE
Add support for alternative urls when post install script runs and downloads grok

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -6,7 +6,10 @@ var util = require('util');
 var https = require('https');
 var DecompressZip = require('decompress-zip');
 
-var source = 'https://dl.ngrok.com/ngrok_2.0.19_';
+var source = (process.env.npm_config_ngrok_cdnurl ||
+	process.env.NGROK_CDNURL || 'https://dl.ngrok.com') + '/ngrok_2.0.19_';
+
+
 var files = {
 	darwinia32:	source + 'darwin_386.zip',
 	darwinx64:	source + 'darwin_amd64.zip',


### PR DESCRIPTION
add option for environment variable replacement of https://ngrok.com in postinstall script to run behind firewall (or limited corporate internet access)

see example in PhantomJS node wrapper support for corporate firewalls https://github.com/Medium/phantomjs/blob/2b644272047fdbcf1d1cfe272fb0f8920ae5c317/install.js