### PR TITLE
Add `files` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "postinstall": "node ./postinstall.js",
     "postupdate": "node ./postinstall.js"
   },
+  "files": [
+    "index.js",
+    "postinstall.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/bubenshchykov/ngrok.git"


### PR DESCRIPTION
This way, users who install this module don't have to download irrelevant stuff like the `test` directory.