### PR TITLE
Do not specify minor versions of node for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "5.1"
-  - "iojs"
+  - "5"
+  - "4"
 os:
   - linux
 before_script:


### PR DESCRIPTION
there is no sense to check particular minor versions on node, for instance in branch "5" minor version "8" is stable and maintained