### PR TITLE
chore(deps): upgrade decompress-zip to avoid future breakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "decompress-zip": "0.1.0",
+    "decompress-zip": "^0.3.0",
     "lock": "^0.1.2",
     "node-uuid": "^1.4.3",
     "request": "^2.55.0",


### PR DESCRIPTION
Hi !

A small PR to bump `decompress-zip` version. That version uses a more up to date version of `graceful-fs` that removes one of the warning while installing :

```sh
❯ npm install ngrok -g
npm WARN deprecated graceful-fs@3.0.8: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
npm WARN deprecated graceful-fs@2.0.3: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
```

The second one should be fixed when https://github.com/mochajs/mocha/pull/2175 is merged and `mocha` is updated.

Thanks 