### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var Emitter = require('events').EventEmitter;
 var platform = require('os').platform();
 var lock = require('lock')();
 var async = require('async');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var xtend = require('xtend');
 
 var bin = './ngrok' + (platform === 'win32' ? '.exe' : '');

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "async": "^0.9.0",
     "decompress-zip": "^0.3.0",
     "lock": "^0.1.2",
-    "node-uuid": "^1.4.3",
     "request": "^2.55.0",
+    "uuid": "^3.0.0",
     "xtend": "^4.0.1"
   },
   "bin": {

--- a/test/ngrok.authtoken.spec.js
+++ b/test/ngrok.authtoken.spec.js
@@ -3,7 +3,7 @@ var http = require('http');
 var net = require('net');
 var request = require('request');
 var URL = require('url');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var util = require('./util');
 
 var port = 8080;

--- a/test/ngrok.guest.spec.js
+++ b/test/ngrok.guest.spec.js
@@ -3,7 +3,7 @@ var http = require('http');
 var net = require('net');
 var request = require('request');
 var URL = require('url');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var util = require('./util');
 
 var port = 8080;

--- a/test/ngrok.registered.free.spec.js
+++ b/test/ngrok.registered.free.spec.js
@@ -3,7 +3,7 @@ var http = require('http');
 var net = require('net');
 var request = require('request');
 var URL = require('url');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var util = require('./util');
 
 var port = 8080;

--- a/test/ngrok.registered.paid.spec.js
+++ b/test/ngrok.registered.paid.spec.js
@@ -3,7 +3,7 @@ var http = require('http');
 var net = require('net');
 var request = require('request');
 var URL = require('url');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var util = require('./util');
 
 var port = 8080;


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.