### PR TITLE
exposed web_addr URL in connect callback

### DIFF
--- a/test/ngrok.guest.eventemitter.spec.js
+++ b/test/ngrok.guest.eventemitter.spec.js
@@ -11,11 +11,12 @@ describe('guest.eventemitter.spec.js - ensuring no authtoken set, using ngrok as
 	});
 
 	describe('connecting to ngrok', function ( ) {
-		var connected, tunnelUrl;
+		var connected, tunnelUrl, webAddrUrl;
 		before(function(done) {
-			ngrok.once('connect', function (url) {
+			ngrok.once('connect', function (url, uiUrl) {
 				connected = true;
 				tunnelUrl = url;
+				webAddrUrl = uiUrl;
 				done();
 			});
 			ngrok.connect();
@@ -27,6 +28,10 @@ describe('guest.eventemitter.spec.js - ensuring no authtoken set, using ngrok as
 
 		it('should pass tunnel url with a "connect" event', function ( ) {
 			expect(tunnelUrl).to.match(/https:\/\/.(.*).ngrok.io/);
+		});
+
+		it('should pass web ui url with a "connect" event', function ( ) {
+			expect(webAddrUrl).to.match(/^http:\/\/127\.0\.0\.1:4040$/);
 		});
 	});
 


### PR DESCRIPTION
This resolves my issue in #72.

It was a fairly simple change since you already did the hard part of extracting the web_addr from stdout so you can call the client API. All I had to do was get the request URI from the response, parse it down to the baseUrl, and add it to the callback args.

Note, I pulled in node's standard URL library for parsing the request URI. Since, your code already had some variables called `url` I could have change the name of the reference to the URL library, but that felt wrong, so I changed the `url` variable to `publicUrl` since that is how ngrok refers to it. I could have only changed the variable name in the function where I used the URL library, but to maintain consistency I changed the other `url` variables to `publicUrl`. There are more line changes than are strictly necessary, but I believe it results in more consistent and maintainable code.

Thank you for making such a great wrapper to ngork. It has allowed me to automate more for my team.