### PR TITLE
Add TypeScript declaration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ngrok [![Build Status](https://travis-ci.org/bubenshchykov/ngrok.png?branch=master)](https://travis-ci.org/bubenshchykov/ngrok)
+ngrok [![Build Status](https://travis-ci.org/bubenshchykov/ngrok.png?branch=master)](https://travis-ci.org/bubenshchykov/ngrok) ![TypeScript compatible](https://img.shields.io/badge/typescript-compatible-brightgreen.svg)
 =====
 
 ![alt ngrok.com](https://ngrok.com/static/img/overview.png)

--- a/ngrok.d.ts
+++ b/ngrok.d.ts
@@ -1,0 +1,124 @@
+/// <reference types="node" />
+
+declare const ngrok: Ngrok;
+
+declare type NgrokToken = string;
+declare type NgrokUrl = string;
+
+declare type Callback<T> = (err?: any, result?: T) => void;
+
+declare type Ngrok = NodeJS.EventEmitter & INgrokWrapper;
+
+declare interface INgrokOptions {
+    /**
+     * Other "custom", indirectly-supported ngrok process options.
+     *
+     * @see {@link https://ngrok.com/docs}
+     */
+    [customOption: string]: any;
+
+    /**
+     * The tunnel type to put in place.
+     *
+     * @default 'http'
+     */
+    proto?: 'http' | 'tcp' | 'tls';
+
+    /**
+     * Port or network address to redirect traffic on.
+     *
+     * @default opts.port || opts.host || 80
+     */
+    addr?: string|number;
+
+    /**
+     * HTTP Basic authentication for tunnel.
+     *
+     * @default opts.httpauth
+     */
+    auth?: string;
+
+    /**
+     * Reserved tunnel name (e.g. https://alex.ngrok.io)
+     */
+    subdomain?: string;
+
+    /**
+     * Your authtoken from ngrok.com
+     */
+    authtoken?: string;
+
+    /**
+     * One of ngrok regions.
+     * Note: region used in first tunnel will be used for all next tunnels too.
+     *
+     * @default 'us'
+     */
+    region?: 'us' | 'eu' | 'au' | 'ap';
+
+    /**
+     * Custom path for ngrok config file.
+     */
+    configPath?: string;
+}
+
+declare interface INgrokWrapper {
+    /**
+     * You can create basic http-https-tcp tunnel without authtoken.
+     * For custom subdomains and more you should obtain authtoken by signing up at ngrok.com.
+     * E.g:
+     *     ngrok.authtoken(token, (err, token) => {});
+     *     ngrok.connect({ authtoken: token, ... }, (err, url) => {});
+     *
+     * @param token
+     * @param callback
+     */
+    authtoken(token: string, callback: Callback<NgrokToken>): void;
+
+    /**
+     * Creates a ngrok HTTP tunnel to http://localhost:80.
+     * E.g. https://757c1652.ngrok.io -> http://localhost:80
+     *
+     * @param callback
+     */
+    connect(callback: Callback<NgrokUrl>): void;
+
+    /**
+     * Creates a ngrok HTTP tunnel to the specified port on localhost.
+     * E.g. https://757c1652.ngrok.io -> http://localhost:9090
+     *
+     * @param port
+     * @param callback
+     */
+    connect(port: number, callback: Callback<NgrokUrl>): void;
+
+    /**
+     * Creates a ngrok tunnel with more advanded configuration.
+     * E.g:
+     *     ngrok.connect({ proto: 'tcp', addr: 22 }, (err, url) => {});
+     *     // => tcp://0.tcp.ngrok.io:48590
+     *
+     * @param options
+     * @param callback
+     */
+    connect(options: INgrokOptions, callback: Callback<NgrokUrl>): void;
+
+    /**
+     * Stops a tunnel, or all of them if no URL is passed.
+     *
+     * /!\ Note on HTTP tunnels: by default bind_tls is true, so whenever you use http proto two tunnels are created:
+     *     http and https. If you disconnect https tunnel, http tunnel remains open.
+     *     You might want to close them both by passing http-version url, or simply by disconnecting all in one,
+     *     with ngrok.disconnect().
+     *
+     * @param url The URL of the specific tunnel to disconnect -- if not passed, kills them all.
+     */
+    disconnect(url?: string): void;
+
+    /**
+     * Kills the ngrok process.
+     */
+    kill(): void;
+}
+
+export = ngrok;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.2.10",
   "description": "node wrapper for ngrok",
   "main": "index.js",
+  "types": "ngrok.d.ts",
   "scripts": {
     "test": "node ./node_modules/mocha/bin/_mocha",
     "postinstall": "node ./postinstall.js",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "mocha": "~3.4.2"
   },
   "dependencies": {
+    "@types/node": "^7.0.31",
     "async": "^2.3.0",
     "decompress-zip": "^0.3.0",
     "lock": "^0.1.2",


### PR DESCRIPTION
Hello @bubenshchykov,

I'm happy to propose you a declaration file for TypeScript.
If you're unfamiliar with TypeScript, that lets API consumers to use dotenv-extended in a type-safe manner.

I could have published the types on DefinitelyTyped, but embedded types are much more practical and are easier to sync when the JavaScript changes.
In fact, bundling types with the original JavaScript library is recommended by the official documentation:

> If you control the npm package you are publishing declarations for, then the first approach is favored. That way, your declarations and JavaScript always travel together.
http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

> If you are the library author, or can make a pull request to the library, bundle types instead of publishing to DefinitelyTyped.
https://github.com/DefinitelyTyped/DefinitelyTyped

Thanks for your work, and I hope you will merge this (I can help to maintain!).

Edit : I see that the Travis build fails because of some unset authentication environment variables. Did I missed something or is it expected?