### PR TITLE
add custom binPath opt when using ngrok in electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ ngrok.connect({
 	authtoken: '12345', // your authtoken from ngrok.com
 	region: 'us' // one of ngrok regions (us, eu, au, ap), defaults to us,
 	configPath: '~/git/project/ngrok.yml' // custom path for ngrok config file
+	binPath: ['app.asar', 'app.asar.unpacked'] // custom path replacement when using for production in electron
 }, function (err, url) {});
 ```
 
 Other options: `name, inspect, host_header, bind_tls, hostname, crt, key, client_cas, remote_addr` - read [here](https://ngrok.com/docs)
+
 
 Note on regions: region used in first tunnel will be used for all next tunnels too.
 

--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ function runNgrok(opts, cb) {
 	}
 
 	var start = ['start', '--none', '--log=stdout'];
+	var dir = __dirname;
 
 	if (opts.region) {
 		start.push('--region=' + opts.region);
@@ -105,10 +106,14 @@ function runNgrok(opts, cb) {
 		start.push('--config=' + opts.configPath);
 	}
 
+	if (opts.binPath) {
+		dir = dir.replace(opts.binPath[0], opts.binPath[1])
+	}
+
 	ngrok = spawn(
 			bin,
 			start,
-			{cwd: __dirname + '/bin'});
+			{cwd: dir + '/bin'});
 
 
 	ngrok.stdout.on('data', function (data) {


### PR DESCRIPTION
Following #106, this PR adds a binPath option when for the connect method that allows to change part of the final __dirname for a custom one, useful when using ngrok together with electron.