### PR TITLE
Fix missing process.js in the packed archive

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "files": [
     "index.js",
     "postinstall.js",
+    "process.js",
     "bin/ngrok",
     "ngrok.d.ts"
   ],


### PR DESCRIPTION
I did a `yarn pack` to test a last time my definition file in another test package (linking packages often gives unexpected results, only a real copy of the package as it will be distributed on npm can give correct results).

And when I tried to `import ... from 'ngrok'`:
> Error: Cannot find module './process'

`process.js` was missing from the `files` array in the `package.json`, and therefore was not present in the npm package archive.