### PR TITLE
Add ca file support (reads from npm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,11 @@ const tunnels = await api.get('api/tunnels');
 ```
 
 ## proxy
-If you are behind a corporate proxy an have issues installing ngrok, you can set ```HTTP_PROXY``` or ```HTTPS_PROXY``` env var to fix it. Ngrok's posinstall uses request module to fetch the binary, [and request supports these env vars](https://github.com/request/request#controlling-proxy-behaviour-using-environment-variables)
+- If you are behind a corporate proxy an have issues installing ngrok, you can set ```HTTP_PROXY``` or ```HTTPS_PROXY``` env var to fix it. Ngrok's posinstall uses request module to fetch the binary, [and request supports these env vars](https://github.com/request/request#controlling-proxy-behaviour-using-environment-variables)
+- If you are using a CA file, set the path in the environment variable `NGROK_ROOT_CA_PATH`. The path is needed for downloading the ngrok binary in the postinstall script.
 
 ## how it works
 ```npm install``` downloads ngrok binary for your platform from official ngrok hosting. To host binaries yourself set NGROK_CDN_URL env var before installing ngrok. To force specific platform set NGROK_ARCH, eg NGROK_ARCH=freebsdia32
-
-- If you are on a corporate network, the cafile will be read from your npmrc file This uses `npm config get ca`, which will read your ca whether you've set it through `npm config set ca` or `npm config set cafile`
 
 First time you create tunnel ngrok process is spawned and runs until you disconnect or when parent process killed. All further tunnels are created or stopped by using internal ngrok api which usually runs on http://127.0.0.1:4040
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ If you are behind a corporate proxy an have issues installing ngrok, you can set
 ## how it works
 ```npm install``` downloads ngrok binary for your platform from official ngrok hosting. To host binaries yourself set NGROK_CDN_URL env var before installing ngrok. To force specific platform set NGROK_ARCH, eg NGROK_ARCH=freebsdia32
 
+- If you are on a corporate network, the cafile will be read from your npmrc file This uses `npm config get ca`, which will read your ca whether you've set it through `npm config set ca` or `npm config set cafile`
+
 First time you create tunnel ngrok process is spawned and runs until you disconnect or when parent process killed. All further tunnels are created or stopped by using internal ngrok api which usually runs on http://127.0.0.1:4040
 
 ## contributors

--- a/package-lock.json
+++ b/package-lock.json
@@ -499,6 +499,12 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "node-forge": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.4.tgz",
+      "integrity": "sha512-UOfdpxivIYY4g5tqp5FNRNgROVNxRACUxxJREntJLFaJr1E0UEqFtUIk0F/jYx/E+Y6sVXd0KDi/m5My0yGCVw==",
+      "dev": true
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "asn1": {
@@ -30,7 +30,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -71,7 +71,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "binary": {
@@ -79,8 +79,8 @@
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "requires": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
+        "buffers": "0.1.1",
+        "chainsaw": "0.1.0"
       }
     },
     "brace-expansion": {
@@ -89,7 +89,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -115,9 +115,9 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
       }
     },
     "chainsaw": {
@@ -125,7 +125,7 @@
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "requires": {
-        "traverse": ">=0.3.0 <0.4"
+        "traverse": "0.3.9"
       }
     },
     "co": {
@@ -144,7 +144,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -169,7 +169,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "debug": {
@@ -186,12 +186,12 @@
       "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.2.tgz",
       "integrity": "sha512-Ab1QY4LrWMrUuo53lLnmGOby7v8ryqxJ+bKibKSiPisx+25mhut1dScVBXAYx14i/PqSrFZvR2FRRazhLbvL+g==",
       "requires": {
-        "binary": "^0.3.0",
-        "graceful-fs": "^4.1.3",
-        "mkpath": "^0.1.0",
-        "nopt": "^3.0.1",
-        "q": "^1.1.2",
-        "readable-stream": "^1.1.8",
+        "binary": "0.3.0",
+        "graceful-fs": "4.1.15",
+        "mkpath": "0.1.0",
+        "nopt": "3.0.6",
+        "q": "1.5.1",
+        "readable-stream": "1.1.14",
         "touch": "0.0.3"
       }
     },
@@ -229,8 +229,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "escape-string-regexp": {
@@ -269,9 +269,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.20"
       },
       "dependencies": {
         "combined-stream": {
@@ -279,7 +279,7 @@
           "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         }
       }
@@ -295,7 +295,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -304,12 +304,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -333,8 +333,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "requires": {
-        "ajv": "^5.3.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has-flag": {
@@ -360,9 +360,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "inflight": {
@@ -371,8 +371,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -442,7 +442,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "~1.36.0"
+        "mime-db": "1.36.0"
       }
     },
     "minimatch": {
@@ -451,7 +451,7 @@
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -499,18 +499,12 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "node-forge": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.4.tgz",
-      "integrity": "sha512-UOfdpxivIYY4g5tqp5FNRNgROVNxRACUxxJREntJLFaJr1E0UEqFtUIk0F/jYx/E+Y6sVXd0KDi/m5My0yGCVw==",
-      "dev": true
-    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "oauth-sign": {
@@ -524,7 +518,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "path-is-absolute": {
@@ -563,10 +557,10 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
         "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "string_decoder": "0.10.31"
       }
     },
     "request": {
@@ -574,26 +568,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.1.0",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.20",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "request-promise-core": {
@@ -601,7 +595,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "4.17.11"
       }
     },
     "request-promise-native": {
@@ -610,8 +604,8 @@
       "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
       },
       "dependencies": {
         "tough-cookie": {
@@ -619,7 +613,7 @@
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           }
         }
       }
@@ -639,15 +633,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stealthy-require": {
@@ -666,7 +660,7 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "touch": {
@@ -674,7 +668,7 @@
       "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
       "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
       "requires": {
-        "nopt": "~1.0.10"
+        "nopt": "1.0.10"
       },
       "dependencies": {
         "nopt": {
@@ -682,7 +676,7 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "requires": {
-            "abbrev": "1"
+            "abbrev": "1.1.1"
           }
         }
       }
@@ -692,8 +686,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.1.29",
+        "punycode": "1.4.1"
       }
     },
     "traverse": {
@@ -706,7 +700,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -731,9 +725,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "chai": "~3.5.0",
     "colors": "^1.3.2",
     "homedir": "^0.6.0",
-    "mocha": "^5.2.0",
-    "node-forge": "^0.8.4"
+    "mocha": "^5.2.0"
   },
   "dependencies": {
     "@types/node": "^8.10.30",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "chai": "~3.5.0",
     "colors": "^1.3.2",
     "homedir": "^0.6.0",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "node-forge": "^0.8.4"
   },
   "dependencies": {
     "@types/node": "^8.10.30",

--- a/postinstall.js
+++ b/postinstall.js
@@ -72,10 +72,14 @@ function hasCache() {
 function download(cb) {
 	console.log('ngrok - downloading binary ' + cdnUrl);
 
-	const caString = execSync('npm config get ca', {stdio: ['ignore', 'pipe', 'pipe']})
+	const caString = execSync('npm config get ca')
 		.toString()
 		.replace(/\'/g, '\"')
-	const ca = caString.substring(0, 25) === '[ "-----BEGIN CERTIFICATE' ? JSON.parse(caString)[0] : undefined;
+
+	const ca = caString.substring(0, 25) === '[ "-----BEGIN CERTIFICATE' 
+		? JSON.parse(caString) 
+		: undefined;
+
 	const options = {
 		url: cdnUrl,
 		ca

--- a/postinstall.js
+++ b/postinstall.js
@@ -11,6 +11,7 @@ const readline = require('readline');
 const Zip = require('decompress-zip');
 const request = require('request');
 const {Transform} = require('stream');
+const execSync = require('child_process').execSync;
 
 const cdnUrl = getCdnUrl();
 const cacheUrl = getCacheUrl();
@@ -71,8 +72,17 @@ function hasCache() {
 function download(cb) {
 	console.log('ngrok - downloading binary ' + cdnUrl);
 
+	const caString = execSync('npm config get ca', {stdio: ['ignore', 'pipe', 'pipe']})
+		.toString()
+		.replace(/\'/g, '\"');
+	const ca = caString !== 'null' ? JSON.parse(caString)[0] : undefined;
+	const options = {
+		url: cdnUrl,
+		ca
+	};
+
 	const downloadStream = request
-		.get(cdnUrl)
+		.get(options)
 		.on('response', res => {
 			if (!/2\d\d/.test(res.statusCode)) {
 				res.pause();

--- a/postinstall.js
+++ b/postinstall.js
@@ -74,8 +74,8 @@ function download(cb) {
 
 	const caString = execSync('npm config get ca', {stdio: ['ignore', 'pipe', 'pipe']})
 		.toString()
-		.replace(/\'/g, '\"');
-	const ca = caString !== 'null' ? JSON.parse(caString)[0] : undefined;
+		.replace(/\'/g, '\"')
+	const ca = caString.substring(0, 25) === '[ "-----BEGIN CERTIFICATE' ? JSON.parse(caString)[0] : undefined;
 	const options = {
 		url: cdnUrl,
 		ca

--- a/test/ngrok.guest.spec.js
+++ b/test/ngrok.guest.spec.js
@@ -165,5 +165,9 @@ describe('guest.spec.js - ensuring no authtoken set', function() {
 			});
 
 		});
+
+		after(async () => {
+			await ngrok.kill();
+		});
 	});
 });

--- a/test/ngrok.postinstall.spec.js
+++ b/test/ngrok.postinstall.spec.js
@@ -6,49 +6,80 @@ const child_process = require('child_process');
 const postinstallPath = path.join(__dirname, '../postinstall.js');
 const ngrokPath = path.join(homedir(), '/.ngrok');
 const certpath = `${ngrokPath}/testCert.pem`;
-const npmrcPath = path.join(homedir(), '.npmrc');
-const npmrcBackupPath = path.join(homedir(), '.npmrc.bak');
 
 describe('postinstall', () => {
-	before(() => {
-		clearNgrokDirectory();
-		writeTestPemFile();
-		updateNpmrc();
+	describe('with no certificate', () => {
+		before(() => {
+			clearNgrokDirectory();
+			writeJunkPemFile();
+			process.env.NGROK_ROOT_CA_PATH = certpath;
+		});
+
+		it('should run using a junk file without crashing', done => {
+			const postinstall = child_process.fork(postinstallPath, { stdio: 'ignore' });
+			postinstall.on('exit', code => done(code));
+		}).timeout(20000);
 	});
 
-	it('should run using invalid CA without crashing', done => {
-		const postinstall = child_process.fork(postinstallPath);
-		postinstall.on('exit', done);
+	describe('with VerisignCertificate', () => {
+		before(() => {
+			clearNgrokDirectory();
+			writeVerisignCertPemFile();
+			process.env.NGROK_ROOT_CA_PATH = certpath;
+		});
+
+		it('should fail to run with an invalid certificate', done => {
+			const postinstall = child_process.fork(postinstallPath, { stdio: 'ignore' });
+			postinstall.on('exit', code => {
+				expect(code).to.equal(1);
+				done();
+			});
+		});
 	});
 
 	after(() => {
 		clearNgrokDirectory();
-		restoreFiles();
 	});
 });
-
-function restoreFiles() {
-	fs.unlinkSync(npmrcPath);
-	if (fs.existsSync(npmrcBackupPath)) {
-		fs.copyFileSync(npmrcBackupPath, npmrcPath);
-	}
-	fs.unlinkSync(npmrcBackupPath);
-}
 
 function clearNgrokDirectory() {
 	const files = fs.readdirSync(ngrokPath);
 	files.forEach(f => fs.unlinkSync(path.join(ngrokPath, f)));
 }
 
-function writeTestPemFile() {
-	const pem = '-junk-to-test-ignore-';
+function writeJunkPemFile() {
+	const pem = 'junk data';
 	fs.writeFileSync(certpath, pem, { flag: 'w' });
 }
-
-function updateNpmrc() {
-	if (fs.existsSync(npmrcPath)) {
-		fs.copyFileSync(npmrcPath, npmrcBackupPath);
-	}
-
-	fs.writeFileSync(npmrcPath, `cafile=${certpath}`, { flag: 'w' });
+function writeVerisignCertPemFile() {
+	const pem = `-----BEGIN CERTIFICATE-----
+MIIEuTCCA6GgAwIBAgIQQBrEZCGzEyEDDrvkEhrFHTANBgkqhkiG9w0BAQsFADCB
+vTELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQL
+ExZWZXJpU2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwOCBWZXJp
+U2lnbiwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MTgwNgYDVQQDEy9W
+ZXJpU2lnbiBVbml2ZXJzYWwgUm9vdCBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAe
+Fw0wODA0MDIwMDAwMDBaFw0zNzEyMDEyMzU5NTlaMIG9MQswCQYDVQQGEwJVUzEX
+MBUGA1UEChMOVmVyaVNpZ24sIEluYy4xHzAdBgNVBAsTFlZlcmlTaWduIFRydXN0
+IE5ldHdvcmsxOjA4BgNVBAsTMShjKSAyMDA4IFZlcmlTaWduLCBJbmMuIC0gRm9y
+IGF1dGhvcml6ZWQgdXNlIG9ubHkxODA2BgNVBAMTL1ZlcmlTaWduIFVuaXZlcnNh
+bCBSb290IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAx2E3XrEBNNti1xWb/1hajCMj1mCOkdeQmIN65lgZOIzF
+9uVkhbSicfvtvbnazU0AtMgtc6XHaXGVHzk8skQHnOgO+k1KxCHfKWGPMiJhgsWH
+H26MfF8WIFFE0XBPV+rjHOPMee5Y2A7Cs0WTwCznmhcrewA3ekEzeOEz4vMQGn+H
+LL729fdC4uW/h2KJXwBL38Xd5HVEMkE6HnFuacsLdUYI0crSK5XQz/u5QGtkjFdN
+/BMReYTtXlT2NJ8IAfMQJQYXStrxHXpma5hgZqTZ79IugvHw7wnqRMkVauIDbjPT
+rJ9VAMf2CGqUuV/c4DPxhGD5WycRtPwW8rtWaoAljQIDAQABo4GyMIGvMA8GA1Ud
+EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMG0GCCsGAQUFBwEMBGEwX6FdoFsw
+WTBXMFUWCWltYWdlL2dpZjAhMB8wBwYFKw4DAhoEFI/l0xqGrI2Oa8PPgGrUSBgs
+exkuMCUWI2h0dHA6Ly9sb2dvLnZlcmlzaWduLmNvbS92c2xvZ28uZ2lmMB0GA1Ud
+DgQWBBS2d/ppSEefUxLVwuoHMnYH0ZcHGTANBgkqhkiG9w0BAQsFAAOCAQEASvj4
+sAPmLGd75JR3Y8xuTPl9Dg3cyLk1uXBPY/ok+myDjEedO2Pzmvl2MpWRsXe8rJq+
+seQxIcaBlVZaDrHC1LGmWazxY8u4TB1ZkErvkBYoH1quEPuBUDgMbMzxPcP1Y+Oz
+4yHJJDnp/RVmRvQbEdBNc6N9Rvk97ahfYtTxP/jgdFcrGJ2BtMQo2pSXpXDrrB2+
+BxHw1dvd5Yzw1TKwg+ZX4o+/vqGqvz0dtdQ46tewXDpPaj+PwGZsY6rp2aQW9IHR
+lRQOfc2VNNnSj3BzgXucfr2YYdhFh5iQxeuGMMY1v/D/w1WIg0vvBZIGcfK4mJO3
+7M2CYfE45k+XmCpajQ==
+-----END CERTIFICATE-----
+`;
+	fs.writeFileSync(certpath, pem, { flag: 'w' });
 }

--- a/test/ngrok.postinstall.spec.js
+++ b/test/ngrok.postinstall.spec.js
@@ -1,0 +1,111 @@
+const homedir = require('homedir');
+const path = require('path');
+const forge = require('node-forge').pki;
+const fs = require('fs');
+const child_process = require('child_process');
+
+const postinstallPath = path.join(__dirname, '../postinstall.js');
+const ngrokPath = path.join(homedir(), '/.ngrok');
+const certpath = `${ngrokPath}/testCert.pem`;
+const npmrcPath = path.join(homedir(), '.npmrc');
+const npmrcBackupPath = path.join(homedir(), '.npmrc.bak');
+
+describe.only('postinstall cert', () => {
+	before(() => {
+		clearNgrokDirectory();
+		writeTestPemFile();
+		updateNpmrc();
+		console.log(fs.readFileSync(npmrcPath).toString());
+	});
+
+	it('should run using CA without crashing', done => {
+		const postinstall = child_process.fork(postinstallPath, { stdio: 'ignore' });
+		postinstall.on('exit', done);
+	});
+
+	after(() => {
+		clearNgrokDirectory();
+		restoreFiles();
+	});
+});
+
+function restoreFiles() {
+	fs.unlinkSync(npmrcPath);
+	fs.copyFileSync(npmrcBackupPath, npmrcPath);
+	fs.unlinkSync(npmrcBackupPath);
+}
+
+function clearNgrokDirectory() {
+	const files = fs.readdirSync(ngrokPath);
+	files.forEach(f => fs.unlinkSync(path.join(ngrokPath, f)));
+}
+
+function writeTestPemFile() {
+	const pem = createPem();
+	fs.writeFileSync(certpath, pem, { flag: 'w' });
+}
+
+function updateNpmrc() {
+	fs.copyFileSync(npmrcPath, npmrcBackupPath);
+	fs.writeFileSync(npmrcPath, `cafile=${certpath}`);
+}
+
+function createPem() {
+	const keys = forge.rsa.generateKeyPair(2048);
+	const cert = forge.createCertificate();
+	cert.publicKey = keys.publicKey;
+	cert.serialNumber = '01';
+	cert.validity.notBefore = new Date();
+	cert.validity.notAfter = new Date();
+	cert.validity.notAfter.setHours(cert.validity.notBefore.getHours() + 1);
+	const attrs = [{ name: 'commonName', value: 'localhost' }];
+	cert.setSubject(attrs);
+	cert.setIssuer(attrs);
+	cert.setExtensions([
+		{
+			name: 'basicConstraints',
+			cA: true
+		},
+		{
+			name: 'keyUsage',
+			keyCertSign: true,
+			digitalSignature: true,
+			nonRepudiation: true,
+			keyEncipherment: true,
+			dataEncipherment: true
+		},
+		{
+			name: 'extKeyUsage',
+			serverAuth: true,
+			clientAuth: true,
+			codeSigning: true,
+			emailProtection: true,
+			timeStamping: true
+		},
+		{
+			name: 'nsCertType',
+			client: true,
+			server: true,
+			email: true,
+			objsign: true,
+			sslCA: true,
+			emailCA: true,
+			objCA: true
+		},
+		{
+			name: 'subjectAltName',
+			altNames: [
+				{
+					type: 7, // IP
+					ip: '127.0.0.1'
+				}
+			]
+		},
+		{
+			name: 'subjectKeyIdentifier'
+		}
+	]);
+	cert.sign(keys.privateKey);
+
+	return forge.certificateToPem(cert);
+}

--- a/test/ngrok.postinstall.spec.js
+++ b/test/ngrok.postinstall.spec.js
@@ -17,7 +17,7 @@ describe('postinstall', () => {
 	});
 
 	it('should run using invalid CA without crashing', done => {
-		const postinstall = child_process.fork(postinstallPath, { stdio: 'ignore' });
+		const postinstall = child_process.fork(postinstallPath);
 		postinstall.on('exit', done);
 	});
 

--- a/test/ngrok.postinstall.spec.js
+++ b/test/ngrok.postinstall.spec.js
@@ -1,6 +1,5 @@
 const homedir = require('homedir');
 const path = require('path');
-const forge = require('node-forge').pki;
 const fs = require('fs');
 const child_process = require('child_process');
 
@@ -10,15 +9,14 @@ const certpath = `${ngrokPath}/testCert.pem`;
 const npmrcPath = path.join(homedir(), '.npmrc');
 const npmrcBackupPath = path.join(homedir(), '.npmrc.bak');
 
-describe.only('postinstall cert', () => {
+describe('postinstall', () => {
 	before(() => {
 		clearNgrokDirectory();
 		writeTestPemFile();
 		updateNpmrc();
-		console.log(fs.readFileSync(npmrcPath).toString());
 	});
 
-	it('should run using CA without crashing', done => {
+	it('should run using invalid CA without crashing', done => {
 		const postinstall = child_process.fork(postinstallPath, { stdio: 'ignore' });
 		postinstall.on('exit', done);
 	});
@@ -31,7 +29,9 @@ describe.only('postinstall cert', () => {
 
 function restoreFiles() {
 	fs.unlinkSync(npmrcPath);
-	fs.copyFileSync(npmrcBackupPath, npmrcPath);
+	if (fs.existsSync(npmrcBackupPath)) {
+		fs.copyFileSync(npmrcBackupPath, npmrcPath);
+	}
 	fs.unlinkSync(npmrcBackupPath);
 }
 
@@ -41,71 +41,14 @@ function clearNgrokDirectory() {
 }
 
 function writeTestPemFile() {
-	const pem = createPem();
+	const pem = '-junk-to-test-ignore-';
 	fs.writeFileSync(certpath, pem, { flag: 'w' });
 }
 
 function updateNpmrc() {
-	fs.copyFileSync(npmrcPath, npmrcBackupPath);
-	fs.writeFileSync(npmrcPath, `cafile=${certpath}`);
-}
+	if (fs.existsSync(npmrcPath)) {
+		fs.copyFileSync(npmrcPath, npmrcBackupPath);
+	}
 
-function createPem() {
-	const keys = forge.rsa.generateKeyPair(2048);
-	const cert = forge.createCertificate();
-	cert.publicKey = keys.publicKey;
-	cert.serialNumber = '01';
-	cert.validity.notBefore = new Date();
-	cert.validity.notAfter = new Date();
-	cert.validity.notAfter.setHours(cert.validity.notBefore.getHours() + 1);
-	const attrs = [{ name: 'commonName', value: 'localhost' }];
-	cert.setSubject(attrs);
-	cert.setIssuer(attrs);
-	cert.setExtensions([
-		{
-			name: 'basicConstraints',
-			cA: true
-		},
-		{
-			name: 'keyUsage',
-			keyCertSign: true,
-			digitalSignature: true,
-			nonRepudiation: true,
-			keyEncipherment: true,
-			dataEncipherment: true
-		},
-		{
-			name: 'extKeyUsage',
-			serverAuth: true,
-			clientAuth: true,
-			codeSigning: true,
-			emailProtection: true,
-			timeStamping: true
-		},
-		{
-			name: 'nsCertType',
-			client: true,
-			server: true,
-			email: true,
-			objsign: true,
-			sslCA: true,
-			emailCA: true,
-			objCA: true
-		},
-		{
-			name: 'subjectAltName',
-			altNames: [
-				{
-					type: 7, // IP
-					ip: '127.0.0.1'
-				}
-			]
-		},
-		{
-			name: 'subjectKeyIdentifier'
-		}
-	]);
-	cert.sign(keys.privateKey);
-
-	return forge.certificateToPem(cert);
+	fs.writeFileSync(npmrcPath, `cafile=${certpath}`, { flag: 'w' });
 }


### PR DESCRIPTION
Please pull this down and run the postinstall script locally as well, just to make sure it's good to go. I will also test from my home network this evening. I've tested as thoroughly as I know how with ca files. I'm pretty sure it's good to go on that front.

This does add a slight delay in the post install script. It takes around a full second on my machine to run the command, unfortunately. I'm not quite sure why, but it also happens from the command prompt.

Feel free to tag me if any issues come up related to this, and I'll get it fixed as soon as I can.