### PR TITLE
Added end certificate tag to string.

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -172,7 +172,8 @@ function tryToReadCaFile() {
 
 		const caContents = caString && caString
 			.split('-----END CERTIFICATE-----')
-			.filter(c => c.trim().startsWith('-----BEGIN CERTIFICATE-----'));
+			.filter(c => c.trim().startsWith('-----BEGIN CERTIFICATE-----'))
+			.map(c => `${c}-----END CERTIFICATE-----`)
 
 		return caContents.length > 0 
 			? caContents 


### PR DESCRIPTION
When I got back into the office this week, I realized that I hadn't fixed #142. The cert wasn't being properly read. I realized that splitting the string was removing the split character, and that a certificate isn't fully parsed until the end tag is actually hit. 

I apologize for missing this. It's a bit tough to test since I don't have the environment set up at home.