### PR TITLE
Add onStatusChange callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ const url = await ngrok.connect({
 	subdomain: 'alex', // reserved tunnel name https://alex.ngrok.io
 	authtoken: '12345', // your authtoken from ngrok.com
 	region: 'us', // one of ngrok regions (us, eu, au, ap), defaults to us
-	configPath: '~/git/project/ngrok.yml' // custom path for ngrok config file
-	binPath: default => default.replace('app.asar', 'app.asar.unpacked'); // custom binary path, eg for prod in electron
+	configPath: '~/git/project/ngrok.yml', // custom path for ngrok config file
+	binPath: default => default.replace('app.asar', 'app.asar.unpacked'), // custom binary path, eg for prod in electron
+	onStatusChange: status => {}, // 'closed' - connection is lost, 'connected' - reconnected
 });
 ```
 

--- a/ngrok.d.ts
+++ b/ngrok.d.ts
@@ -96,4 +96,10 @@ interface INgrokOptions {
      * Custom binary path, eg for prod in electron
      */
     binPath?: (defaultPath: string) => string;
+
+    /**
+     * Callback called when session status is changed. 
+     * When connection is lost, ngrok will keep trying to reconnect.
+     */
+    onStatusChange?: (status: 'connected' | 'closed') => any;
 }

--- a/process.js
+++ b/process.js
@@ -44,6 +44,13 @@ async function startProcess (opts) {
 	ngrok.stdout.on('data', data => {
 		const msg = data.toString();
 		const addr = msg.match(ready);
+		if (opts.onStatusChange) {
+			if (msg.match('client session established')) {
+				opts.onStatusChange('connected');
+			} else if (msg.match('session closed, starting reconnect loop')) {
+				opts.onStatusChange('closed');
+			}
+		}
 		if (addr) {
 			resolve(`http://${addr[1]}`);
 		} else if (msg.match(inUse)) {
@@ -73,7 +80,7 @@ async function startProcess (opts) {
 		throw ex;
 	}
 	finally {
-		ngrok.stdout.removeAllListeners('data');
+		if (!opts.onStatusChange) ngrok.stdout.removeAllListeners('data');
 		ngrok.stderr.removeAllListeners('data');
 	}
 }

--- a/test/ngrok.guest.spec.js
+++ b/test/ngrok.guest.spec.js
@@ -164,6 +164,24 @@ describe('guest.spec.js - ensuring no authtoken set', function() {
 
 			});
 
+			describe('connecting to ngrok with onStatusChange callback', function() {
+
+				before(async () => await ngrok.kill());
+	
+				it('should be called with correct status', async function() {	
+					let resolve;
+					const statusChangePromise = new Promise(res => resolve = res);			
+					await ngrok.connect({
+						port,
+						onStatusChange: status => {
+							if (status === 'connected') resolve();
+						},
+					});
+					await statusChangePromise;
+				});
+	
+			});
+
 		});
 
 		after(async () => {


### PR DESCRIPTION
Added onStatusChange callback. 

Fired initially with 'connected' status. When connection is lost, called with 'closed'. ngrok will be trying to reconnect. If successful, you'll get 'connected' again.

resolves #114