### PR TITLE
Support sa, jp, in regions using TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const url = await ngrok.connect({
 	auth: 'user:pwd', // http basic authentication for tunnel
 	subdomain: 'alex', // reserved tunnel name https://alex.ngrok.io
 	authtoken: '12345', // your authtoken from ngrok.com
-	region: 'us', // one of ngrok regions (us, eu, au, ap), defaults to us
+	region: 'us', // one of ngrok regions (us, eu, au, ap, sa, jp, in), defaults to us
 	configPath: '~/git/project/ngrok.yml', // custom path for ngrok config file
 	binPath: default => default.replace('app.asar', 'app.asar.unpacked'), // custom binary path, eg for prod in electron
 	onStatusChange: status => {}, // 'closed' - connection is lost, 'connected' - reconnected

--- a/ngrok.d.ts
+++ b/ngrok.d.ts
@@ -97,7 +97,7 @@ interface INgrokOptions {
      *
      * @default 'us'
      */
-    region?: 'us' | 'eu' | 'au' | 'ap';
+    region?: 'us' | 'eu' | 'au' | 'ap' | 'sa' | 'jp' | 'in';
 
     /**
      * Custom path for ngrok config file.


### PR DESCRIPTION
Hi, thank you for your awesome library!

I have added 'sa', 'jp', 'in' regions to fix TypeScript error `Types of property 'region' are incompatible` ☺️ 

refs. `region` part of https://ngrok.com/docs#config-options 🙏 
