### PR TITLE
Fix executable path in windows 10 bash.

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -1,3 +1,25 @@
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+const pkgName = require('./package.json').name;
+
 require('./download')(err => {
+  // Fix default executable path on Windows Git Bash
+  if (!err && process.env.MSYSTEM && os.release().includes('10')) {
+    const exeFile = path.resolve(process.env.APPDATA, path.join('npm', pkgName));
+
+    if (fs.existsSync(exeFile)) {
+      const parsedContent = fs
+        .readFileSync(exeFile)
+        .toString()
+        .replace(
+          `"$basedir/node_modules/${pkgName}/bin/${pkgName}"`,
+          `"winpty" "$basedir/node_modules/${pkgName}/bin/${pkgName}.exe"`
+        );
+
+      fs.writeFileSync(exeFile, parsedContent);
+    }
+  }
+
   process.exit(err ? 1 : 0);
 });


### PR DESCRIPTION
Workaround for `ngrok` in Windows 10 Git Bash environment:

![image](https://user-images.githubusercontent.com/26286907/77829693-d8566480-7134-11ea-9776-c5c7aa995dee.png)


Resolves https://github.com/bubenshchykov/ngrok/issues/58