### PR TITLE
Adjustments for types.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ const request = require('request-promise-native');
 const uuid = require('uuid');
 const {getProcess, killProcess, setAuthtoken} = require('./process');
 
-let processUrl;
-let internalApi;
+let processUrl = null;
+let internalApi = null;
 let tunnels = {};
 
 async function connect (opts) {

--- a/ngrok.d.ts
+++ b/ngrok.d.ts
@@ -33,12 +33,12 @@ export function kill(): Promise<void>;
 /**
  * Gets the ngrok client URL.
  */
-export function getUrl(): string;
+export function getUrl(): string | null;
 
 /**
  * Gets the ngrok client API.
  */
-export function getApi(): RequestAPI<Request, CoreOptions, RequiredUriUrl>;
+export function getApi(): RequestAPI<Request, CoreOptions, RequiredUriUrl> | null;
 
 /**
  * You can create basic http-https-tcp tunnel without authtoken.


### PR DESCRIPTION
The `internalApi` starts as `undefined`, gets set to an object when connecting to the ngrok process and when the process is killed is set to `null`. I wanted to simplify the states here to only either `null` or the request object. Consequently the return type of `getApi` should also be updated to reflect that it may be `null`. If you'd prefer not to change the states, I could change the return type of `getApi` to `RequestAPI<Request, CoreOptions, RequiredUriUrl> | null | undefined`.

Whilst making the changes for `internalApi`, it seemed more consistent to do the same for `processUrl` and the `getUrl` function.

What do you think?