### PR TITLE
Only add one process.exit handler

### DIFF
--- a/process.js
+++ b/process.js
@@ -6,7 +6,7 @@ const bin = './ngrok' + (platform === 'win32' ? '.exe' : '');
 const ready = /starting web service.*addr=(\d+\.\d+\.\d+\.\d+:\d+)/;
 const inUse = /address already in use/;
 
-let processPromise, activeProcess;
+let processPromise, activeProcess, processHasExit;
 
 /*
 	ngrok process runs internal ngrok api
@@ -71,7 +71,10 @@ async function startProcess (opts) {
 		activeProcess = null;
 	});
 
-	process.on('exit', async () => await killProcess());
+        if (!processHasExit) {
+	        process.on('exit', async () => await killProcess());
+                processHasExit = true;
+        }
 
 	try {
 		const url = await apiUrl;


### PR DESCRIPTION
If you create short-lived tunnels then each time it binds a method to the process.on('exit') until error messages start being emitted - 

```
(node:17328) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added to [process]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
```