### PR TITLE
Replace request with got

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const apiUrl = ngrok.getUrl();
 ```
 
 ## proxy
-- If you are behind a corporate proxy an have issues installing ngrok, you can set ```HTTP_PROXY``` or ```HTTPS_PROXY``` env var to fix it. Ngrok's postinstall uses request module to fetch the binary, [and request supports these env vars](https://github.com/request/request#controlling-proxy-behaviour-using-environment-variables)
+- If you are behind a corporate proxy an have issues installing ngrok, you can set ```HTTPS_PROXY``` env var to fix it. Ngrok's postinstall use the [`got`](https://www.npmjs.com/package/got) module to fetch the binary and the [`hpagent`](https://github.com/delvedor/hpagent) module to support HTTPS proxies. You will need to install the `hpagent` module as a dependency
 - If you are using a CA file, set the path in the environment variable `NGROK_ROOT_CA_PATH`. The path is needed for downloading the ngrok binary in the postinstall script.
 
 ## how it works

--- a/client.js
+++ b/client.js
@@ -44,7 +44,7 @@ class NgrokClient {
   }
 
   startTunnel(options={}) {
-    return this.request('post', 'api/tunnels', options );
+    return this.request('post', 'api/tunnels', options);
   }
 
   tunnelDetail(name) {

--- a/client.js
+++ b/client.js
@@ -1,5 +1,14 @@
 const got = require('got');
 
+class NgrokClientError extends Error {
+  constructor(message, response, body) {
+    super(message);
+    this.name = "NgrokClientError";
+    this.response = response;
+    this.body = body;
+  }
+}
+
 class NgrokClient {
   constructor(processUrl) {
     this.internalApi = got.extend({
@@ -8,36 +17,64 @@ class NgrokClient {
     });
   }
 
-  listTunnels() {
-    return this.internalApi.get('api/tunnels').json();
+  async request(method, path, options={}) {
+    try {
+      if (method === "get") {
+        return await this.internalApi.get(path, { searchParams: options }).json();
+      } else {
+        return await this.internalApi[method](path, { json: options }).json();
+      }
+    } catch(error) {
+      const response = JSON.parse(error.response.body);
+      throw new NgrokClientError(response.msg, error.response, response);
+    }
   }
 
-  startTunnel(options) {
-    return this.internalApi.post('api/tunnels', { json: options }).json();
+  async booleanRequest(method, path, options={}) {
+    try {
+      return await this.internalApi[method](path, { json: options }).then(response => response.statusCode === 204)
+    } catch(error) {
+      const response = JSON.parse(error.response.body);
+      throw new NgrokClientError(response.msg, error.response, response);
+    }
+  }
+
+  listTunnels() {
+    return this.request('get', 'api/tunnels');
+  }
+
+  startTunnel(options={}) {
+    return this.request('post', 'api/tunnels', options );
   }
 
   tunnelDetail(name) {
-    return this.internalApi.get(`api/tunnels/${name}`).json();
+    return this.request('get', `api/tunnels/${name}`);
   }
 
-  stopTunnel(tunnelUrl) {
-    return this.internalApi.delete(tunnelUrl.replace(/^\//, '')).json();
+  stopTunnel(name) {
+    if (typeof name === 'undefined' || name.length === 0) {
+      throw new Error("To stop a tunnel, please provide a name.");
+    }
+    return this.booleanRequest('delete', `api/tunnels/${name}`);
   }
 
   listRequests(options) {
-    return this.internalApi.get('api/requests/http', { searchParams: options }).json();
+    return this.request('get', 'api/requests/http', options);
   }
 
   replayRequest(id, tunnelName) {
-    return this.internalApi.post('api/requests/http', {json: { id, tunnelName }}).then(response => response.statusCode === 204);
+    return this.booleanRequest('post', 'api/requests/http', { id, tunnelName });
   }
 
   deleteAllRequests() {
-    return this.internalApi.delete('api/requests/http').then(response => response.statusCode === 204);
+    return this.booleanRequest('delete', 'api/requests/http');
   }
 
   requestDetail(id) {
-    return this.internalApi.get(`api/requests/http/${id}`).json();
+    if (typeof id === 'undefined' || id.length === 0) {
+      throw new Error("To get the details of a request, please provide an id.");
+    }
+    return this.request('get', `api/requests/http/${id}`);
   }
 }
 

--- a/client.js
+++ b/client.js
@@ -1,0 +1,44 @@
+const got = require('got');
+
+class NgrokClient {
+  constructor(processUrl) {
+    this.internalApi = got.extend({
+      prefixUrl: processUrl,
+      retry: 0
+    });
+  }
+
+  listTunnels() {
+    return this.internalApi.get('api/tunnels').json();
+  }
+
+  startTunnel(options) {
+    return this.internalApi.post('api/tunnels', { json: options }).json();
+  }
+
+  tunnelDetail(name) {
+    return this.internalApi.get(`api/tunnels/${name}`).json();
+  }
+
+  stopTunnel(tunnelUrl) {
+    return this.internalApi.delete(tunnelUrl.replace(/^\//, '')).json();
+  }
+
+  listRequests(options) {
+    return this.internalApi.get('api/requests/http', { searchParams: options }).json();
+  }
+
+  replayRequest(id, tunnelName) {
+    return this.internalApi.post('api/requests/http', {json: { id, tunnelName }}).then(response => response.statusCode === 204);
+  }
+
+  deleteAllRequests() {
+    return this.internalApi.delete('api/requests/http').then(response => response.statusCode === 204);
+  }
+
+  requestDetail(id) {
+    return this.internalApi.get(`api/requests/http/${id}`).json();
+  }
+}
+
+module.exports = { NgrokClient };

--- a/download.js
+++ b/download.js
@@ -82,7 +82,20 @@ function downloadNgrok(callback, options) {
 
     const certificateAuthority = tryToReadCaFile();
 
-    const downloadStream = got.stream(cdnUrl, { https: { certificateAuthority }});
+    const gotOptions = { https: { certificateAuthority }};
+
+    if (process.env.HTTPS_PROXY) {
+      try {
+        const {HttpsProxyAgent} = require('hpagent');
+        gotOptions.agent = {
+          https: new HttpsProxyAgent({ proxy: process.env.HTTPS_PROXY })
+        }
+      } catch(error) {
+        throw new Error('You have the HTTPS_PROXY environment variable set, but you are missing the optional dependency hpagent. Please install hpagent as a dependency and try again.');
+      }
+    }
+
+    const downloadStream = got.stream(cdnUrl, gotOptions);
     process.stderr.write("ngrok - downloading progress: ");
     downloadStream
       .on('response', (res) => {

--- a/index.js
+++ b/index.js
@@ -58,7 +58,6 @@ async function connectRetry (opts, retryCount = 0) {
 
 function isRetriable (err) {
   if (!err.response){
-    console.log("Inside isRetriable", err);
     return false;
   }
   const statusCode = err.response.statusCode

--- a/index.js
+++ b/index.js
@@ -50,7 +50,9 @@ async function connectRetry (opts, retryCount = 0) {
   } catch (err) {
     if (!isRetriable(err) || retryCount >= 100) {
       if (err.response) {
-        throw JSON.parse(err.response.body);
+        const response = JSON.parse(err.response.body);
+        const message =  `${response.msg}\n\n${response.details.err}`;
+        throw new Error(message);
       }
       throw err.error;
     }

--- a/index.js
+++ b/index.js
@@ -37,19 +37,10 @@ async function connectRetry (opts, retryCount = 0) {
   opts.name = String(opts.name || uuid.v4());
   try {
     const response = await ngrokClient.startTunnel(opts);
-    const publicUrl = response.public_url;
-    if (!publicUrl) {
-      throw new Error('failed to start tunnel');
-    }
-    return publicUrl;
+    return response.public_url;
   } catch (err) {
     if (!isRetriable(err) || retryCount >= 100) {
-      if (err.response) {
-        const response = JSON.parse(err.response.body);
-        const message =  `${response.msg}\n\n${response.details.err}`;
-        throw new Error(message);
-      }
-      throw err.error;
+      throw(err);
     }
     await new Promise((resolve) => setTimeout(resolve, 200));
     return connectRetry(opts, ++retryCount);

--- a/ngrok.d.ts
+++ b/ngrok.d.ts
@@ -208,7 +208,7 @@ declare module "ngrok" {
     listTunnels(): Promise<Ngrok.TunnelsResponse>;
     startTunnel(options: Ngrok.Options): Promise<Ngrok.Tunnel>;
     tunnelDetail(name: string): Promise<Ngrok.Tunnel>;
-    stopTunnel(tunnelUrl: string): Promise<boolean>;
+    stopTunnel(name: string): Promise<boolean>;
     listRequests(
       options: Ngrok.CapturedRequestOptions
     ): Promise<Ngrok.RequestsResponse>;

--- a/ngrok.d.ts
+++ b/ngrok.d.ts
@@ -1,130 +1,233 @@
-import { CoreOptions, Request, RequestAPI, RequiredUriUrl } from 'request';
+declare module "ngrok" {
+  /**
+   * Creates a ngrok tunnel.
+   * E.g:
+   *     const url = await ngrok.connect(); // https://757c1652.ngrok.io -> http://localhost:80
+   *     const url = await ngrok.connect(9090); // https://757c1652.ngrok.io -> http://localhost:9090
+   *     const url = await ngrok.connect({ proto: 'tcp', addr: 22 }); // tcp://0.tcp.ngrok.io:48590
+   *
+   * @param options Optional. Port number or options.
+   */
+  export function connect(options?: number | Ngrok.Options): Promise<string>;
 
-/**
- * Creates a ngrok tunnel.
- * E.g:
- *     const url = await ngrok.connect(); // https://757c1652.ngrok.io -> http://localhost:80
- *     const url = await ngrok.connect(9090); // https://757c1652.ngrok.io -> http://localhost:9090
- *     const url = await ngrok.connect({ proto: 'tcp', addr: 22 }); // tcp://0.tcp.ngrok.io:48590
- *
- * @param options Optional. Port number or options.
- */
-export function connect(options?: number | INgrokOptions): Promise<string>;
+  /**
+   * Stops a tunnel, or all of them if no URL is passed.
+   *
+   * /!\ ngrok and all opened tunnels will be killed when the node process is done.
+   *
+   * /!\ Note on HTTP tunnels: by default bind_tls is true, so whenever you use http proto two tunnels are created:
+   *     http and https. If you disconnect https tunnel, http tunnel remains open.
+   *     You might want to close them both by passing http-version url, or simply by disconnecting all in one,
+   *     with ngrok.disconnect().
+   *
+   * @param url The URL of the specific tunnel to disconnect -- if not passed, kills them all.
+   */
+  export function disconnect(url?: string): Promise<void>;
 
-/**
- * Stops a tunnel, or all of them if no URL is passed.
- *
- * /!\ ngrok and all opened tunnels will be killed when the node process is done.
- *
- * /!\ Note on HTTP tunnels: by default bind_tls is true, so whenever you use http proto two tunnels are created:
- *     http and https. If you disconnect https tunnel, http tunnel remains open.
- *     You might want to close them both by passing http-version url, or simply by disconnecting all in one,
- *     with ngrok.disconnect().
- *
- * @param url The URL of the specific tunnel to disconnect -- if not passed, kills them all.
- */
-export function disconnect(url?: string): Promise<void>;
+  /**
+   * Kills the ngrok process.
+   */
+  export function kill(): Promise<void>;
 
-/**
- * Kills the ngrok process.
- */
-export function kill(): Promise<void>;
+  /**
+   * Gets the ngrok client URL.
+   */
+  export function getUrl(): string | null;
 
-/**
- * Gets the ngrok client URL.
- */
-export function getUrl(): string | null;
+  /**
+   * Gets the ngrok client API.
+   */
+  export function getApi(): NgrokClient | null;
 
-/**
- * Gets the ngrok client API.
- */
-export function getApi(): RequestAPI<Request, CoreOptions, RequiredUriUrl> | null;
+  /**
+   * You can create basic http-https-tcp tunnel without authtoken.
+   * For custom subdomains and more you should obtain authtoken by signing up at ngrok.com.
+   * E.g:
+   *     await ngrok.authtoken(token);
+   *     // or
+   *     await ngrok.authtoken({ authtoken: token, ... });
+   *     // or
+   *     const url = await ngrok.connect({ authtoken: token, ... });
+   *
+   * @param token
+   */
+  export function authtoken(token: string | Ngrok.Options): Promise<void>;
 
-/**
- * You can create basic http-https-tcp tunnel without authtoken.
- * For custom subdomains and more you should obtain authtoken by signing up at ngrok.com.
- * E.g:
- *     await ngrok.authtoken(token);
- *     // or
- *     await ngrok.authtoken({ authtoken: token, ... });
- *     // or
- *     const url = await ngrok.connect({ authtoken: token, ... });
- *
- * @param token
- */
-export function authtoken(token: string | INgrokOptions): Promise<void>;
+  /**
+   *
+   * Gets the version of the ngrok binary.
+   */
+  export function getVersion(options?: Ngrok.Options): Promise<string>;
 
-/**
- *
- * Gets the version of the ngrok binary.
- */
-export function getVersion(options?: INgrokOptions): Promise<string>;
+  namespace Ngrok {
+    type Protocol = "http" | "tcp" | "tls";
+    type Region = "us" | "eu" | "au" | "ap" | "sa" | "jp" | "in";
 
-interface INgrokOptions {
-    /**
-     * Other "custom", indirectly-supported ngrok process options.
-     *
-     * @see {@link https://ngrok.com/docs}
-     */
-    [customOption: string]: any;
+    interface Options {
+      /**
+       * Other "custom", indirectly-supported ngrok process options.
+       *
+       * @see {@link https://ngrok.com/docs}
+       */
+      [customOption: string]: any;
 
-    /**
-     * The tunnel type to put in place.
-     *
-     * @default 'http'
-     */
-    proto?: 'http' | 'tcp' | 'tls';
+      /**
+       * The tunnel type to put in place.
+       *
+       * @default 'http'
+       */
+      proto?: Protocol;
 
-    /**
-     * Port or network address to redirect traffic on.
-     *
-     * @default opts.port || opts.host || 80
-     */
-    addr?: string | number;
+      /**
+       * Port or network address to redirect traffic on.
+       *
+       * @default opts.port || opts.host || 80
+       */
+      addr?: string | number;
 
-    /**
-     * HTTP Basic authentication for tunnel.
-     *
-     * @default opts.httpauth
-     */
-    auth?: string;
+      /**
+       * HTTP Basic authentication for tunnel.
+       *
+       * @default opts.httpauth
+       */
+      auth?: string;
 
-    /**
-     * Reserved tunnel name (e.g. https://alex.ngrok.io)
-     */
-    subdomain?: string;
+      /**
+       * Reserved tunnel name (e.g. https://alex.ngrok.io)
+       */
+      subdomain?: string;
 
-    /**
-     * Your authtoken from ngrok.com
-     */
-    authtoken?: string;
+      /**
+       * Your authtoken from ngrok.com
+       */
+      authtoken?: string;
 
-    /**
-     * One of ngrok regions.
-     * Note: region used in first tunnel will be used for all next tunnels too.
-     *
-     * @default 'us'
-     */
-    region?: 'us' | 'eu' | 'au' | 'ap' | 'sa' | 'jp' | 'in';
+      /**
+       * One of ngrok regions.
+       * Note: region used in first tunnel will be used for all next tunnels too.
+       *
+       * @default 'us'
+       */
+      region?: Region;
 
-    /**
-     * Custom path for ngrok config file.
-     */
-    configPath?: string;
+      /**
+       * Custom path for ngrok config file.
+       */
+      configPath?: string;
 
-    /**
-     * Custom binary path, eg for prod in electron
-     */
-    binPath?: (defaultPath: string) => string;
+      /**
+       * Custom binary path, eg for prod in electron
+       */
+      binPath?: (defaultPath: string) => string;
 
-    /**
-     * Callback called when ngrok logs an event.
-     */
-    onLogEvent?: (logEventMessage: string) => any;
+      /**
+       * Callback called when ngrok logs an event.
+       */
+      onLogEvent?: (logEventMessage: string) => any;
 
-    /**
-     * Callback called when session status is changed.
-     * When connection is lost, ngrok will keep trying to reconnect.
-     */
-    onStatusChange?: (status: 'connected' | 'closed') => any;
+      /**
+       * Callback called when session status is changed.
+       * When connection is lost, ngrok will keep trying to reconnect.
+       */
+      onStatusChange?: (status: "connected" | "closed") => any;
+    }
+
+    interface Metrics {
+      count: number;
+      rate1: number;
+      rate5: number;
+      rate15: number;
+      p50: number;
+      p90: number;
+      p95: number;
+      p99: number;
+    }
+
+    interface Connections extends Metrics {
+      gauge: number;
+    }
+
+    interface HTTPRequests extends Metrics {}
+
+    interface Tunnel {
+      name: string;
+      uri: string;
+      public_url: string;
+      proto: Ngrok.Protocol;
+      metrics: {
+        conns: Connections;
+        http: HTTPRequests;
+      };
+    }
+
+    interface TunnelsResponse {
+      tunnels: Tunnel[];
+      uri: string;
+    }
+
+    interface CapturedRequestOptions {
+      limit: number;
+      tunnel_name: string;
+    }
+
+    interface Request {
+      uri: string;
+      id: string;
+      tunnel_name: string;
+      remote_addr: string;
+      start: string;
+      duration: number;
+      request: {
+        method: string;
+        proto: string;
+        headers: {
+          [header: string]: string;
+        };
+        uri: string;
+        raw: string;
+      };
+      response: {
+        status: string;
+        status_code: number;
+        proto: string;
+        headers: {
+          [header: string]: string;
+        };
+        raw: string;
+      };
+    }
+
+    interface RequestsResponse {
+      requests: Request[];
+      uri: string;
+    }
+  }
+
+  class NgrokClient {
+    constructor(processUrl: string);
+    listTunnels(): Promise<Ngrok.TunnelsResponse>;
+    startTunnel(options: Ngrok.Options): Promise<Ngrok.Tunnel>;
+    tunnelDetail(name: string): Promise<Ngrok.Tunnel>;
+    stopTunnel(tunnelUrl: string): Promise<boolean>;
+    listRequests(
+      options: Ngrok.CapturedRequestOptions
+    ): Promise<Ngrok.RequestsResponse>;
+    replayRequest(id: string, tunnelName: string): Promise<boolean>;
+    deleteAllRequests(): Promise<boolean>;
+    requestDetail(id: string): Promise<Request>;
+  }
+}
+
+declare module "ngrok/download" {
+  function downloadNgrok(
+    callback: (err?: Error) => void,
+    options?: {
+      cafilePath: string;
+      arch: string;
+      cdnUrl: string;
+      cdnPath: string;
+      ignoreCache: boolean;
+    }
+  ): void;
+  export = downloadNgrok;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,47 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sindresorhus/is": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.0.tgz",
+      "integrity": "sha512-n4J+zu52VdY43kdi/XdI9DzuMr1Mur8zFL5ZRG2opCans9aiFwkPxHYFEb5Xgy7n1Z4K6WfI4FpqUqsh3E8BPQ=="
+    },
+    "@szmarczak/http-timer": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
+    "@types/cacheable-request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
     "@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="
+    },
+    "@types/keyv": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/node": {
       "version": "8.10.50",
@@ -35,6 +72,14 @@
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/tough-cookie": {
@@ -137,6 +182,25 @@
       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
     },
+    "cacheable-lookup": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz",
+      "integrity": "sha512-W+JBqF9SWe18A72XFzN/V/CULFzPm7sBXzzR6ekkE+3tLG72wFZrBiBZhrZuDoYexop4PHJVdFAKb/Nj9+tm9w=="
+    },
+    "cacheable-request": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^2.0.0"
+      }
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -159,6 +223,14 @@
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "requires": {
         "traverse": ">=0.3.0 <0.4"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "^1.0.0"
       }
     },
     "co": {
@@ -214,6 +286,21 @@
         "ms": "2.0.0"
       }
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
+    },
     "decompress-zip": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.2.tgz",
@@ -245,6 +332,11 @@
         }
       }
     },
+    "defer-to-connect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+      "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -264,6 +356,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
       }
     },
     "escape-string-regexp": {
@@ -323,6 +423,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "get-stream": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -343,6 +451,24 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "got": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.5.1.tgz",
+      "integrity": "sha512-reQEZcEBMTGnujmQ+Wm97mJs/OK6INtO6HmLI+xt3+9CvnRwWjXutUvb2mqr+Ao4Lu05Rx6+udx9sOQAmExMxA==",
+      "requires": {
+        "@sindresorhus/is": "^3.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.0",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -388,6 +514,11 @@
       "integrity": "sha1-KyHbZr8Ipts4JJo+/1LX0YcGrx4=",
       "dev": true
     },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -396,6 +527,15 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "http2-wrapper": {
+      "version": "1.0.0-beta.5.2",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
+      "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
       }
     },
     "inflight": {
@@ -434,6 +574,11 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -460,10 +605,23 @@
         "verror": "1.10.0"
       }
     },
+    "keyv": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",
+      "integrity": "sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==",
+      "requires": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+    },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
     },
     "mime-db": {
       "version": "1.36.0",
@@ -477,6 +635,11 @@
       "requires": {
         "mime-db": "~1.36.0"
       }
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -540,6 +703,11 @@
         "abbrev": "1"
       }
     },
+    "normalize-url": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -549,10 +717,14 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
+    },
+    "p-cancelable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+      "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -570,6 +742,15 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
       "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -584,6 +765,11 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "readable-stream": {
       "version": "1.1.14",
@@ -639,6 +825,19 @@
         "request-promise-core": "1.1.2",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
+      }
+    },
+    "resolve-alpn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
+      "integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA=="
+    },
+    "responselike": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "requires": {
+        "lowercase-keys": "^2.0.0"
       }
     },
     "safe-buffer": {
@@ -756,8 +955,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -325,6 +325,12 @@
       "integrity": "sha1-KyHbZr8Ipts4JJo+/1LX0YcGrx4=",
       "dev": true
     },
+    "hpagent": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.1.tgz",
+      "integrity": "sha512-IxJWQiY0vmEjetHdoE9HZjD4Cx+mYTr25tR7JCxXaiI3QxW0YqYyM11KyZbHufoa/piWhMb2+D3FGpMgmA2cFQ==",
+      "optional": true
+    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,11 +28,6 @@
         "@types/responselike": "*"
       }
     },
-    "@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
-    },
     "@types/http-cache-semantics": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
@@ -51,29 +46,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.50.tgz",
       "integrity": "sha512-+ZbcUwJdaBgOZpwXeT0v+gHC/jQbEfzoc9s4d0rN0JIKeQbuTrT+A2n1aQY6LpZjrLXJT7avVUqiCecCJeeZxA=="
     },
-    "@types/request": {
-      "version": "2.48.2",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.2.tgz",
-      "integrity": "sha512-gP+PSFXAXMrd5PcD7SqHeUjdGshAI8vKQ3+AvpQr3ht9iQea+59LOKvKITcQI+Lg+1EIkDP6AFSBUJPWG8GDyA==",
-      "requires": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
-          "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -82,39 +54,10 @@
         "@types/node": "*"
       }
     },
-    "@types/tough-cookie": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
-    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
-      }
-    },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
       "version": "1.0.2",
@@ -122,35 +65,11 @@
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "binary": {
       "version": "0.3.0",
@@ -201,11 +120,6 @@
         "responselike": "^2.0.0"
       }
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
     "chai": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
@@ -233,24 +147,11 @@
         "mimic-response": "^1.0.0"
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "colors": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
       "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true
-    },
-    "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
     },
     "commander": {
       "version": "2.15.1",
@@ -268,14 +169,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "debug": {
       "version": "3.1.0",
@@ -337,26 +230,11 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
       "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg=="
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "optional": true,
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -372,51 +250,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "dependencies": {
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        }
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -429,14 +262,6 @@
       "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
       "requires": {
         "pump": "^3.0.0"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -482,20 +307,6 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-      "requires": {
-        "ajv": "^5.3.0",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -518,16 +329,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
     },
     "http2-wrapper": {
       "version": "1.0.0-beta.5.2",
@@ -553,57 +354,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
     },
     "keyv": {
       "version": "4.0.1",
@@ -613,28 +372,10 @@
         "json-buffer": "3.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
-    },
     "lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
-    },
-    "mime-db": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
-    },
-    "mime-types": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
-      "requires": {
-        "mime-db": "~1.36.0"
-      }
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -708,11 +449,6 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -732,16 +468,6 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
-    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -751,20 +477,10 @@
         "once": "^1.3.1"
       }
     },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "quick-lru": {
       "version": "5.1.1",
@@ -782,51 +498,6 @@
         "string_decoder": "~0.10.x"
       }
     },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
-      "requires": {
-        "lodash": "^4.17.11"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
-      "requires": {
-        "request-promise-core": "1.1.2",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      }
-    },
     "resolve-alpn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
@@ -839,37 +510,6 @@
       "requires": {
         "lowercase-keys": "^2.0.0"
       }
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string_decoder": {
       "version": "0.10.31",
@@ -903,33 +543,10 @@
         }
       }
     },
-    "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      }
-    },
     "traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
     },
     "type-detect": {
       "version": "1.0.0",
@@ -941,16 +558,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "ngrok": "./bin/ngrok"
   },
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=10.19.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
   },
   "engines": {
     "node": ">=10.19.0"
+  },
+  "optionalDependencies": {
+    "hpagent": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,11 +41,8 @@
   },
   "dependencies": {
     "@types/node": "^8.10.50",
-    "@types/request": "^2.48.2",
     "decompress-zip": "^0.3.2",
     "got": "^11.5.1",
-    "request": "^2.88.0",
-    "request-promise-native": "^1.0.7",
     "uuid": "^3.3.2"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "postinstall.js",
     "process.js",
     "bin/ngrok",
-    "ngrok.d.ts"
+    "ngrok.d.ts",
+    "client.js"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^8.10.50",
     "@types/request": "^2.48.2",
     "decompress-zip": "^0.3.2",
+    "got": "^11.5.1",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "uuid": "^3.3.2"

--- a/process.js
+++ b/process.js
@@ -102,7 +102,7 @@ function killProcess ()  {
 }
 
 /**
- * @param {string | INgrokOptions} optsOrToken
+ * @param {string | Ngrok.Options} optsOrToken
  */
 async function setAuthtoken (optsOrToken) {
 	const isOpts = typeof optsOrToken !== 'string'

--- a/test/ngrok.authtoken.spec.js
+++ b/test/ngrok.authtoken.spec.js
@@ -1,8 +1,6 @@
 const ngrok = require('..');
 const http = require('http');
-const net = require('net');
-const request = require('request');
-const URL = require('url');
+const got = require('got');
 const uuid = require('uuid');
 const util = require('./util');
 
@@ -40,7 +38,7 @@ let tunnelUrl, respBody;
 
 		describe('connecting to ngrok with authtoken and subdomain', function () {
 			const uniqDomain = 'koko-' + uuid.v4();
-			
+
 			before(async () => {
 				tunnelUrl = await ngrok.connect({
 					port: port,
@@ -55,11 +53,8 @@ let tunnelUrl, respBody;
 
 			describe('calling local server through ngrok', function() {
 
-				before(function(done) {
-					request.get(tunnelUrl + '/ngrok-subdomain', function (err, resp, body) {
-						respBody = body;
-						done(err);
-					});
+				before(function() {
+					return got(tunnelUrl + '/ngrok-subdomain').text().then(body => respBody = body);
 				});
 
 				it('should return oki-doki too', function() {
@@ -67,6 +62,6 @@ let tunnelUrl, respBody;
 				});
 
 			});
-		});	
+		});
 	});
 });

--- a/test/ngrok.guest.spec.js
+++ b/test/ngrok.guest.spec.js
@@ -154,8 +154,8 @@ describe('guest.spec.js - ensuring no authtoken set', function() {
 				});
 
 				it('should return error', function(){
-					expect(error.msg).to.equal('failed to start tunnel');
-					expect(error.details.err).to.contain('Only paid plans may bind custom subdomains');
+					expect(error.message).to.contain('failed to start tunnel');
+					expect(error.message).to.contain('Only paid plans may bind custom subdomains');
 				});
 
 			});

--- a/test/ngrok.guest.spec.js
+++ b/test/ngrok.guest.spec.js
@@ -155,7 +155,7 @@ describe('guest.spec.js - ensuring no authtoken set', function() {
 
 				it('should return error', function(){
 					expect(error.message).to.contain('failed to start tunnel');
-					expect(error.message).to.contain('Only paid plans may bind custom subdomains');
+					expect(error.body.details.err).to.contain('Only paid plans may bind custom subdomains');
 				});
 
 			});

--- a/test/ngrok.guest.spec.js
+++ b/test/ngrok.guest.spec.js
@@ -1,8 +1,6 @@
 const ngrok = require('..');
 const http = require('http');
-const net = require('net');
-const request = require('request-promise-native');
-const URL = require('url');
+const got = require('got');
 const uuid = require('uuid');
 const util = require('./util');
 
@@ -34,8 +32,8 @@ describe('guest.spec.js - ensuring no authtoken set', function() {
 
 		describe('calling local server directly', function() {
 
-			before(async function () {
-				respBody = await request.get(localUrl + '/local');
+			before(function () {
+				return got(localUrl + '/local').text().then(body => respBody = body);
 			});
 
 			it('should return oki-doki', function() {
@@ -63,9 +61,8 @@ describe('guest.spec.js - ensuring no authtoken set', function() {
 
 						let tunnelResponse;
 
-						before(async () => {
-							tunnelResponse = await request.get(url + '/api/tunnels');
-							tunnelResponse = JSON.parse(tunnelResponse);
+						before(() => {
+							return got(url + '/api/tunnels', { responseType: 'json' }).json().then(body => tunnelResponse = body);
 						});
 
 						it('should give you the open tunnel uri', () => {
@@ -85,8 +82,8 @@ describe('guest.spec.js - ensuring no authtoken set', function() {
 
 				describe('calling local server through ngrok', function() {
 
-					before(async function () {
-						respBody = await request.get(tunnelUrl + '/ngrok');
+					before(function () {
+						return got(tunnelUrl + '/ngrok').text().then(body => respBody = body);
 					});
 
 					it('should return oki-doki too', function() {
@@ -101,12 +98,8 @@ describe('guest.spec.js - ensuring no authtoken set', function() {
 
 						describe('calling local server through disconnected https ngrok', function() {
 
-							before(async function () {
-								try {
-									await request.get(tunnelUrl + '/ngrok')
-								} catch (err) {
-									respBody = err.response.body
-								}
+							before(function () {
+								return got(tunnelUrl + '/ngrok').catch(err => respBody = err.response.body);
 							});
 
 							it('should return error message', function() {
@@ -117,12 +110,8 @@ describe('guest.spec.js - ensuring no authtoken set', function() {
 
 						describe('calling local server through disconnected http ngrok', function() {
 
-							before(async function () {
-								try {
-									await request.get(tunnelUrl.replace('https', 'http') + '/ngrok');
-								} catch (err) {
-									respBody = err.response.body
-								}
+							before(function () {
+								return got(tunnelUrl.replace('https', 'http') + '/ngrok').catch(err => respBody = err.response.body);
 							});
 
 							it('should return error message', function() {

--- a/test/ngrok.registered.free.spec.js
+++ b/test/ngrok.registered.free.spec.js
@@ -1,9 +1,8 @@
 const ngrok = require('..');
 const http = require('http');
 const net = require('net');
-const request = require('request');
+const got = require('got');
 const URL = require('url');
-const uuid = require('uuid');
 const util = require('./util');
 
 const port = 8080;
@@ -38,12 +37,9 @@ describe('registered.free.spec.js - setting free authtoken', function() {
 		});
 
 		describe('calling local server directly', function() {
-			
-			before(function(done) {
-				request.get(localUrl + '/local', function (err, resp, body) {
-					respBody = body;
-					done(err);
-				});
+
+			before(function() {
+				return got(localUrl + '/local').text().then(body => respBody = body);
 			});
 
 			it('should return oki-doki', function() {
@@ -62,11 +58,8 @@ describe('registered.free.spec.js - setting free authtoken', function() {
 
 				describe('calling local server through ngrok', function() {
 
-					before(function(done) {
-						request.get(tunnelUrl + '/ngrok', function (err, resp, body) {
-							respBody = body;
-							done(err);
-						});
+					before(function() {
+						return got(tunnelUrl + '/ngrok').text().then(body => respBody = body);
 					});
 
 					it('should return oki-doki too', function() {
@@ -79,11 +72,8 @@ describe('registered.free.spec.js - setting free authtoken', function() {
 
 						describe('calling local server through discconected ngrok', function() {
 
-							before(function(done) {
-								request.get(tunnelUrl + '/ngrok', function (err, resp, body) {
-									respBody = body;
-									done(err);
-								});
+							before(function() {
+								return got(tunnelUrl + '/ngrok').text().then(body => respBody = body).catch(err => respBody = err.response.body)
 							});
 
 							it('should return error message', function() {
@@ -98,7 +88,6 @@ describe('registered.free.spec.js - setting free authtoken', function() {
 			});
 
 			describe('connecting to ngrok with auth', function () {
-				
 				before(async () => {
 					tunnelUrl = await ngrok.connect({
 						port: port,
@@ -112,11 +101,8 @@ describe('registered.free.spec.js - setting free authtoken', function() {
 
 				describe('calling local server through ngrok without http authorization', function() {
 
-					before(function(done) {
-						request.get(tunnelUrl + '/ngrok-httpauth', function (err, resp, body) {
-							respBody = body;
-							done(err);
-						});
+					before(function() {
+						return got(tunnelUrl + '/ngrok-httpauth').text().then(body => respBody = body).catch(err => respBody = err.response.body);
 					});
 
 					it('should return error message', function() {
@@ -127,11 +113,8 @@ describe('registered.free.spec.js - setting free authtoken', function() {
 
 				describe('calling local server through ngrok with http authorization', function() {
 
-					before(function(done) {
-						request.get(tunnelUrl + '/ngrok-httpauth', {auth: {user: 'oki', password: 'doki'}}, function (err, resp, body) {
-							respBody = body;
-							done(err);
-						});
+					before(function() {
+						return got(tunnelUrl + '/ngrok-httpauth', {username: 'oki', password: 'doki'}).text().then(body => respBody = body);
 					});
 
 					it('should return oki-doki too', function() {
@@ -145,7 +128,7 @@ describe('registered.free.spec.js - setting free authtoken', function() {
 	});
 
 	describe('starting local tcp server', function () {
-			
+
 		let tcpServerPort;
 		before(function(done) {
 			const tcpServer = net.createServer(function(socket) {
@@ -177,7 +160,7 @@ describe('registered.free.spec.js - setting free authtoken', function() {
 			describe('calling local tcp server through ngrok', function() {
 				let socketData;
 				let socket;
-				
+
 				before(function (done) {
 					net.connect(+tunnelUrlParts.port, tunnelUrlParts.hostname)
 						.once('data', function(data) {

--- a/test/ngrok.registered.paid.spec.js
+++ b/test/ngrok.registered.paid.spec.js
@@ -130,8 +130,8 @@ let tunnelUrl, respBody;
 					});
 
 					it('should return an error that the tunnel is already established', function () {
-						expect(error.msg).to.equal('failed to start tunnel');
-						expect(error.details.err).to.contain('is already bound to another tunnel session');
+						expect(error.message).to.equal('failed to start tunnel');
+						expect(error.body.details.err).to.contain('is already bound to another tunnel session');
 					});
 				});
 

--- a/test/ngrok.registered.paid.spec.js
+++ b/test/ngrok.registered.paid.spec.js
@@ -1,8 +1,7 @@
-const colors = require('colors/safe');
 const ngrok = require('..');
 const http = require('http');
 const net = require('net');
-const request = require('request');
+const got = require('got');
 const URL = require('url');
 const uuid = require('uuid');
 const util = require('./util');
@@ -40,12 +39,9 @@ let tunnelUrl, respBody;
 		});
 
 		describe('calling local server directly', function() {
-			
-			before(function(done) {
-				request.get(localUrl + '/local', function (err, resp, body) {
-					respBody = body;
-					done(err);
-				});
+
+			before(function() {
+				return got(localUrl + '/local').text().then(body => respBody = body);
 			});
 
 			it('should return oki-doki', function() {
@@ -64,11 +60,8 @@ let tunnelUrl, respBody;
 
 				describe('calling local server through ngrok', function() {
 
-					before(function(done) {
-						request.get(tunnelUrl + '/ngrok', function (err, resp, body) {
-							respBody = body;
-							done(err);
-						});
+					before(function() {
+						return got(tunnelUrl + '/ngrok').text().then(body => respBody = body);
 					});
 
 					it('should return oki-doki too', function() {
@@ -79,13 +72,10 @@ let tunnelUrl, respBody;
 
 						before(async () => await ngrok.disconnect());
 
-						describe('calling local server through discconected ngrok', function() {
+						describe('calling local server through disconnected ngrok', function() {
 
-							before(function(done) {
-								request.get(tunnelUrl + '/ngrok', function (err, resp, body) {
-									respBody = body;
-									done(err);
-								});
+							before(function() {
+								return got(tunnelUrl + '/ngrok').text().then(body => respBody = body).catch(err => respBody = err.response.body);
 							});
 
 							it('should return error message', function() {
@@ -101,7 +91,7 @@ let tunnelUrl, respBody;
 
 			describe('connecting to ngrok with subdomain', function () {
 				const uniqDomain = 'koko-' + uuid.v4();
-				
+
 				before(async () => {
 					tunnelUrl = await ngrok.connect({
 						port: port,
@@ -115,11 +105,8 @@ let tunnelUrl, respBody;
 
 				describe('calling local server through ngrok', function() {
 
-					before(function(done) {
-						request.get(tunnelUrl + '/ngrok-subdomain', function (err, resp, body) {
-							respBody = body;
-							done(err);
-						});
+					before(function() {
+						return got(tunnelUrl + '/ngrok-subdomain').text().then(body => respBody = body);
 					});
 
 					it('should return oki-doki too', function() {
@@ -167,7 +154,7 @@ let tunnelUrl, respBody;
 			});
 
 			describe('connecting to ngrok with auth', function () {
-				
+
 				before(async () => {
 					tunnelUrl = await ngrok.connect({
 						port: port,
@@ -181,11 +168,8 @@ let tunnelUrl, respBody;
 
 				describe('calling local server through ngrok without http authorization', function() {
 
-					before(function(done) {
-						request.get(tunnelUrl + '/ngrok-httpauth', function (err, resp, body) {
-							respBody = body;
-							done(err);
-						});
+					before(function() {
+						return got(tunnelUrl + '/ngrok-httpauth').text().then(body => respBody = body).catch(err => respBody = err.response.body);
 					});
 
 					it('should return error message', function() {
@@ -196,11 +180,8 @@ let tunnelUrl, respBody;
 
 				describe('calling local server through ngrok with http authorization', function() {
 
-					before(function(done) {
-						request.get(tunnelUrl + '/ngrok-httpauth', {auth: {user: 'oki', password: 'doki'}}, function (err, resp, body) {
-							respBody = body;
-							done(err);
-						});
+					before(function() {
+						return got(tunnelUrl + '/ngrok-httpauth', {username: 'oki', password: 'doki'}).text().then(body => respBody = body);
 					});
 
 					it('should return oki-doki too', function() {
@@ -214,7 +195,7 @@ let tunnelUrl, respBody;
 	});
 
 	describe('starting local tcp server', function () {
-			
+
 		let tcpServerPort;
 		before(function(done) {
 			const tcpServer = net.createServer(function(socket) {
@@ -246,7 +227,7 @@ let tunnelUrl, respBody;
 			describe('calling local tcp server through ngrok', function() {
 				let socketData;
 				let socket;
-				
+
 				before(function (done) {
 					net.connect(+tunnelUrlParts.port, tunnelUrlParts.hostname)
 						.once('data', function(data) {


### PR DESCRIPTION
[Request is deprecated](https://www.npmjs.com/package/request) so this project should move on.

This pull request replaces request with [got](https://www.npmjs.com/package/got) which is a popular HTTP client that supports promises and streams (as used in `download.js`). I feel the result is actually simpler, which is nice, and has more deletions than additions as well as fewer dependencies.

As part of this, I did adjust a couple of things, such as:

* Rather than expose the underlying http client (previously the request client and now the got client) wrap up an `NgrokClient` class with the available API methods and expose that.
* Use `console.error` or `process.stderr` for most logging in `download.js` (mainly based on [reading this](https://www.jstorimer.com/blogs/workingwithcode/7766119-when-to-use-stderr-instead-of-stdout)).
* Removed some unused requires

This is a breaking change and will require a new version. I also have not done anything with the embedded types, which are now out of date with this code.

I hope you are interested in this work. I understand that I chose a new dependency and did this all myself without raising an issue, so if you have a HTTP client that you would prefer to use or even completely different plans, then I do not mind.

Let me know if you have any thoughts or questions. Cheers!