### PR TITLE
Misc Windows fixes

### DIFF
--- a/download.js
+++ b/download.js
@@ -57,7 +57,9 @@ function downloadNgrok(callback, options) {
   function getCacheUrl() {
     let dir;
     try {
-      dir = path.join(os.homedir(), '.ngrok');
+      dir = os.platform() === 'win32' && process.env.APPDATA
+        ? path.join(process.env.APPDATA, 'ngrok')
+        : path.join(os.homedir(), '.ngrok');
       if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
         fs.mkdirSync(dir);
       }

--- a/process.js
+++ b/process.js
@@ -4,7 +4,7 @@ const exec = promisify(execCallback);
 const platform = require('os').platform();
 
 const defaultDir = __dirname + '/bin';
-const bin = './ngrok' + (platform === 'win32' ? '.exe' : '');
+const bin = platform === 'win32' ? 'ngrok.exe' : './ngrok';
 const ready = /starting web service.*addr=(\d+\.\d+\.\d+\.\d+:\d+)/;
 const inUse = /address already in use/;
 


### PR DESCRIPTION
Summary of changes:

1. Changed the download script to use `%APPDATA%` instead of `~/.ngrok` on Windows
2. Fixed an error in the `ngrok --version` test

If you are going to merge this, please add a `hacktoberfest-accepted` label to this PR if possible