### PR TITLE
fix: support for darwin arm64

### DIFF
--- a/download.js
+++ b/download.js
@@ -35,6 +35,7 @@ function downloadNgrok(callback, options) {
     const cdnFiles = {
       darwinia32: cdn + cdnPath + 'darwin-386.zip',
       darwinx64: cdn + cdnPath + 'darwin-amd64.zip',
+      darwinarm64: cdn + cdnPath + 'darwin-amd64.zip',
       linuxarm: cdn + cdnPath + 'linux-arm.zip',
       linuxarm64: cdn + cdnPath + 'linux-arm64.zip',
       androidarm: cdn + cdnPath + 'linux-arm.zip',


### PR DESCRIPTION
Instead of failing because the dictionary doesn't contain the key corresponding to this architecture,
Use the amd64 binary.
This is sufficient, on a arm64 host, to install and successfully execute `portless`, and to establish a secure http tunnel to port 80.

fixes #201 