### PR TITLE
Run CI tests on different operating systems

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,10 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10.x, 12.x, 14.x]
       max-parallel: 1
 

--- a/test/ngrok.postinstall.spec.js
+++ b/test/ngrok.postinstall.spec.js
@@ -1,18 +1,27 @@
-const homedir = require('homedir');
-const path = require('path');
+const { join } = require('path');
 const fs = require('fs');
 const child_process = require('child_process');
 
-const postinstallPath = path.join(__dirname, '../postinstall.js');
-const ngrokPath = path.join(homedir(), '/.ngrok');
+const postinstallPath = join(__dirname, '../postinstall.js');
+const ngrokPath = join(__dirname, 'fixtures', '.ngrok');
+fs.mkdirSync(ngrokPath, { recursive: true });
 const certpath = `${ngrokPath}/testCert.pem`;
 
 describe('postinstall', () => {
+	before(() => {
+		process.env.NGROK_ROOT_CA_PATH = certpath;
+		process.env.NGROK_IGNORE_CACHE = 'true';
+	});
+
+	after(() => {
+		delete process.env.NGROK_IGNORE_CACHE
+		delete process.env.NGROK_ROOT_CA_PATH
+	});
+
 	describe('with no certificate', () => {
 		before(() => {
 			clearNgrokDirectory();
 			writeJunkPemFile();
-			process.env.NGROK_ROOT_CA_PATH = certpath;
 		});
 
 		it('should run using a junk file without crashing', done => {
@@ -25,7 +34,6 @@ describe('postinstall', () => {
 		before(() => {
 			clearNgrokDirectory();
 			writeVerisignCertPemFile();
-			process.env.NGROK_ROOT_CA_PATH = certpath;
 		});
 
 		it('should fail to run with an invalid certificate', done => {
@@ -44,7 +52,7 @@ describe('postinstall', () => {
 
 function clearNgrokDirectory() {
 	const files = fs.readdirSync(ngrokPath);
-	files.forEach(f => fs.unlinkSync(path.join(ngrokPath, f)));
+	files.forEach(f => fs.unlinkSync(join(ngrokPath, f)));
 }
 
 function writeJunkPemFile() {


### PR DESCRIPTION
Now we have GitHub Actions running the tests, we can run across different platforms easily. This will give greater confidence when releasing new versions as I don't currently have a windows machine set up to test with.

One test failed, which lead me to refactor the postinstall tests. They now perform the work within the `test` directory rather than touching the home directory.