### PR TITLE
Hide Window while Spawning

### DIFF
--- a/src/process.js
+++ b/src/process.js
@@ -36,7 +36,7 @@ async function startProcess (opts) {
 	if (opts.configPath) start.push('--config=' + opts.configPath);
 	if (opts.binPath) dir = opts.binPath(dir);
 
-	const ngrok = spawn(bin, start, {cwd: dir});
+	const ngrok = spawn(bin, start, {cwd: dir, windowsHide: true});
 
 	let resolve, reject;
 	const apiUrl = new Promise((res, rej) => {
@@ -115,7 +115,7 @@ async function setAuthtoken (optsOrToken) {
 
 	let dir = defaultDir;
 	if (opts.binPath) dir = opts.binPath(dir)
-	const ngrok = spawn(bin, authtoken, {cwd: dir});
+	const ngrok = spawn(bin, authtoken, {cwd: dir, windowsHide: true});
 
 	const killed = new Promise((resolve, reject) => {
 		ngrok.stdout.once('data', () => resolve());


### PR DESCRIPTION
It only for Windows
So right now while connect or auth it will show a shell window and for connect it will re-spawn window when close window manually until nodejs thread terminated

So i adding spawn option flag `windowsHide: true` while call `child_process.spawn` to prevent showing shell window

See: https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options