### PR TITLE
fix(process): removes ./ in path that was causing issues

### DIFF
--- a/process.js
+++ b/process.js
@@ -4,7 +4,7 @@ const exec = promisify(execCallback);
 const platform = require('os').platform();
 
 const defaultDir = __dirname + '/bin';
-const bin = './ngrok' + (platform === 'win32' ? '.exe' : '');
+const bin = 'ngrok' + (platform === 'win32' ? '.exe' : '');
 const ready = /starting web service.*addr=(\d+\.\d+\.\d+\.\d+:\d+)/;
 const inUse = /address already in use/;
 


### PR DESCRIPTION
In ngrok-for-vscode#24 (https://github.com/philnash/ngrok-for-vscode/issues/24) there was a spawn error. I tracked it down to the ./ before the command. in process.js. Removing iit made the command work again.