### PR TITLE
Use full path to ngrok executable

### DIFF
--- a/process.js
+++ b/process.js
@@ -137,7 +137,7 @@ async function setAuthtoken (optsOrToken) {
 async function getVersion(opts = {}) {
 	let dir = defaultDir;
 	if (opts.binPath) dir = opts.binPath(dir);
-	const { stdout } = await exec(`${bin} --version`, { cwd: dir });
+	const { stdout } = await exec(`${join(dir, bin)} --version`);
 	return stdout.replace('ngrok version', '').trim();
 }
 

--- a/process.js
+++ b/process.js
@@ -1,10 +1,11 @@
 const { promisify } = require("util")
+const { join } = require("path");
 const { spawn, exec: execCallback } = require('child_process');
 const exec = promisify(execCallback);
 const platform = require('os').platform();
 
-const defaultDir = __dirname + '/bin';
-const bin = './ngrok' + (platform === 'win32' ? '.exe' : '');
+const defaultDir = join(__dirname, 'bin');
+const bin = 'ngrok' + (platform === 'win32' ? '.exe' : '');
 const ready = /starting web service.*addr=(\d+\.\d+\.\d+\.\d+:\d+)/;
 const inUse = /address already in use/;
 
@@ -35,7 +36,7 @@ async function startProcess (opts) {
 	if (opts.configPath) start.push('--config=' + opts.configPath);
 	if (opts.binPath) dir = opts.binPath(dir);
 
-	const ngrok = spawn(bin, start, {cwd: dir});
+	const ngrok = spawn(join(dir, bin), start);
 
 	let resolve, reject;
 	const apiUrl = new Promise((res, rej) => {
@@ -114,7 +115,8 @@ async function setAuthtoken (optsOrToken) {
 
 	let dir = defaultDir;
 	if (opts.binPath) dir = opts.binPath(dir)
-	const ngrok = spawn(bin, authtoken, {cwd: dir});
+
+	const ngrok = spawn(join(dir, bin), authtoken);
 
 	const killed = new Promise((resolve, reject) => {
 		ngrok.stdout.once('data', () => resolve());


### PR DESCRIPTION
Started getting an [`ENOENT` error in `ngrok-for-vscode`](https://github.com/philnash/ngrok-for-vscode/issues/24). It couldn't find the ngrok executable to spawn.

This PR ensures we try to use `spawn` on the full path to the executable instead of setting the `cwd` of `spawn` which seems to fix it.