### PR TITLE
Fix NgrokClient.requestDetail type definition

### DIFF
--- a/ngrok.d.ts
+++ b/ngrok.d.ts
@@ -214,7 +214,7 @@ declare module "ngrok" {
     ): Promise<Ngrok.RequestsResponse>;
     replayRequest(id: string, tunnelName: string): Promise<boolean>;
     deleteAllRequests(): Promise<boolean>;
-    requestDetail(id: string): Promise<Request>;
+    requestDetail(id: string): Promise<Ngrok.Request>;
   }
 }
 


### PR DESCRIPTION
Type definition for NgrokClient.requestDetail was missing Ngrok namespace in return type