### PR TITLE
Fixes alternative download path.

### DIFF
--- a/download.js
+++ b/download.js
@@ -70,7 +70,7 @@ function downloadNgrok(callback, options) {
         fs.mkdirSync(dir);
       }
     } catch (err) {
-      dir = path.join(__dirname, "..", "bin");
+      dir = path.join(__dirname, "bin");
     }
     const name = Buffer.from(cdnUrl).toString("base64");
     return path.join(dir, name + ".zip");


### PR DESCRIPTION
When I was rearranging files in the lead up to releasing version 4 I had to alter where the downloaded file went because `download.js` had moved up a level. Then I moved it back down a level and didn't update the download location. This undoes that issue and makes downloads happy again.

Fixes #236.