### PR TITLE
Fix download type definition and report NGROK process termination

### DIFF
--- a/download.d.ts
+++ b/download.d.ts
@@ -1,0 +1,13 @@
+declare module "ngrok/download" {
+    function downloadNgrok(
+      callback: (err?: Error) => void,
+      options?: {
+        cafilePath: string;
+        arch: string;
+        cdnUrl: string;
+        cdnPath: string;
+        ignoreCache: boolean;
+      }
+    ): void;
+    export = downloadNgrok;
+  }

--- a/ngrok.d.ts
+++ b/ngrok.d.ts
@@ -232,17 +232,3 @@ declare module "ngrok" {
     get body(): ErrorBody | string;
   }
 }
-
-declare module "ngrok/download" {
-  function downloadNgrok(
-    callback: (err?: Error) => void,
-    options?: {
-      cafilePath: string;
-      arch: string;
-      cdnUrl: string;
-      cdnPath: string;
-      ignoreCache: boolean;
-    }
-  ): void;
-  export = downloadNgrok;
-}

--- a/ngrok.d.ts
+++ b/ngrok.d.ts
@@ -132,6 +132,11 @@ declare module "ngrok" {
        * When connection is lost, ngrok will keep trying to reconnect.
        */
       onStatusChange?: (status: "connected" | "closed") => any;
+
+       /**
+       * Callback called when ngrok host process is terminated.
+       */
+      onTerminated?: () => any;
     }
 
     interface Metrics {

--- a/src/process.js
+++ b/src/process.js
@@ -86,6 +86,9 @@ async function startProcess(opts) {
   ngrok.on("exit", () => {
     processPromise = null;
     activeProcess = null;
+    if (opts.onTerminated) {
+      opts.onTerminated();
+    }
   });
 
   try {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -58,6 +58,7 @@ describe("utils", () => {
       const binPath = () => {};
       const onLogEvent = () => {};
       const onStatusChange = () => {};
+      const onTerminated = () => {};
       expect(
         defaults({
           configPath,
@@ -65,6 +66,7 @@ describe("utils", () => {
           binPath,
           onLogEvent,
           onStatusChange,
+          onTerminated,
         })
       ).to.deep.equal({
         configPath,
@@ -75,6 +77,7 @@ describe("utils", () => {
         binPath,
         onLogEvent,
         onStatusChange,
+        onTerminated,
       });
     });
 


### PR DESCRIPTION
When using the ngrok package in TypeScript, the compiler produces the following error: "Invalid module name in augmentation". The pull request fixes this issue. I have tested that the download function can be accessed successfully via `import ngrokdownload from "ngrok/download"`.

When the ngrok tunnel closes, the consumer is notified by the "closed" status event. This is the happy path. When the ngrok process closes unexpectedly, the consumer is not notified, and will be unaware that a tunnel no longer exists. Added new onTerminate option.