### PR TITLE
Improvements for getApi()

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,8 @@ async function getApi() {
   }
 
   const ngrokProcessUrl = await getProcessUrl();
-  return new NgrokClient(`http://${ngrokProcessUrl}:4040/`);
+
+  return ngrokProcessUrl ? new NgrokClient(`http://${ngrokProcessUrl}:4040/`) : null;
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { NgrokClient, NgrokClientError } = require("./src/client");
 const uuid = require("uuid");
 const {
   getProcess,
+  getProcessUrl,
   killProcess,
   setAuthtoken,
   getVersion,
@@ -66,8 +67,13 @@ function getUrl() {
   return processUrl;
 }
 
-function getApi() {
-  return ngrokClient;
+async function getApi() {
+  if (ngrokClient) {
+    return ngrokClient;
+  }
+
+  const ngrokProcessUrl = await getProcessUrl();
+  return new NgrokClient(`http://${ngrokProcessUrl}:4040/`);
 }
 
 module.exports = {
@@ -78,5 +84,6 @@ module.exports = {
   getUrl,
   getApi,
   getVersion,
+  NgrokClient,
   NgrokClientError
 };

--- a/ngrok.d.ts
+++ b/ngrok.d.ts
@@ -39,7 +39,7 @@ declare module "ngrok" {
   /**
    * Gets the ngrok client API.
    */
-  export function getApi(): NgrokClient | null;
+  export function getApi(): NgrokClient | Promise<NgrokClient> | null;
 
   /**
    * You can create basic http-https-tcp tunnel without authtoken.

--- a/ngrok.d.ts
+++ b/ngrok.d.ts
@@ -39,7 +39,7 @@ declare module "ngrok" {
   /**
    * Gets the ngrok client API.
    */
-  export function getApi(): NgrokClient | Promise<NgrokClient> | null;
+  export function getApi(): Promise<NgrokClient | null>;
 
   /**
    * You can create basic http-https-tcp tunnel without authtoken.

--- a/src/process.js
+++ b/src/process.js
@@ -27,6 +27,10 @@ async function getProcess(opts) {
   }
 }
 
+/*
+  In order to get the local process URL where ngrok is running, first check the platform, 
+  then spawn a child process to gather the URL and clean the output if necessary
+*/
 async function getProcessUrl(port = 4040) {
   return new Promise((resolve, reject) => {
 

--- a/test/ngrok.guest.spec.js
+++ b/test/ngrok.guest.spec.js
@@ -3,7 +3,6 @@ const http = require("http");
 const got = require("got");
 const uuid = require("uuid");
 const util = require("./util");
-const { expect } = require("chai");
 
 const port = 8080;
 const localUrl = "http://127.0.0.1:" + port;
@@ -76,7 +75,7 @@ describe("guest.spec.js - ensuring no authtoken set", function () {
 
         describe("getting internal api wrapper", () => {
           let api;
-          before(async () => api = await ngrok.getApi());
+          before(async () => api = (await ngrok.getApi()));
           it("should give you ngrok api", () => {
             expect(api).to.be.ok;
           });

--- a/test/ngrok.guest.spec.js
+++ b/test/ngrok.guest.spec.js
@@ -3,6 +3,7 @@ const http = require("http");
 const got = require("got");
 const uuid = require("uuid");
 const util = require("./util");
+const { expect } = require("chai");
 
 const port = 8080;
 const localUrl = "http://127.0.0.1:" + port;
@@ -75,9 +76,12 @@ describe("guest.spec.js - ensuring no authtoken set", function () {
 
         describe("getting internal api wrapper", () => {
           let api;
-          before(() => (api = ngrok.getApi()));
+          before(async () => api = await ngrok.getApi());
           it("should give you ngrok api", () => {
             expect(api).to.be.ok;
+          });
+          it("should be an instance of NgrokClient", async () => {
+            expect(api).to.be.instanceOf(ngrok.NgrokClient);
           });
         });
 


### PR DESCRIPTION
Solution for #252 

Changes

`index.js` - `getApi()`
- Check if `ngrokClient` is defined, return if so. Else, Call `getProcessUrl` to get the process URL for port 4040, and create a new instance of `NgrokClient`. Fallback to null.

`src/process.js`
- Include `getProcessUrl` which spawns a child process and makes the platform appropriate query for port 4040's process URL.

`ngrok.d.ts`
- Update `getApi()` type definition to return a nullable promise.

`test/ngrok.guest.spec.js`
- Update `"getting internal api wrapper"` test case to call `getApi()` with async/await.
- Include additional assertion `"should be an instance of NgrokClient"` .

---

Tests run successfully on Mac, Windows 10, and Linux. Open to any improvements!