### PR TITLE
Fixes issue when requesting an HTML page with a free account.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- ngrok now returns an information and login page when you try to request an HTML site with a guest account, which broke the tests. Fixed the broken test and added one to specifically test the behaviour.
+
 ## [4.2.2] - 2021-09-06
 
 ### Fixed
@@ -23,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Added `onTerminated` callback to notify users when the underlying ngrok 
+- Added `onTerminated` callback to notify users when the underlying ngrok
   process terminates
 
 ### Fixed

--- a/test/ngrok.registered.free.spec.js
+++ b/test/ngrok.registered.free.spec.js
@@ -109,7 +109,7 @@ describe("registered.free.spec.js - setting free authtoken", function () {
           });
 
           it("should return error message", function () {
-            expect(respBody).to.contain("Authorization Failed");
+            expect(respBody).to.contain("401 Unauthorized");
           });
         });
 


### PR DESCRIPTION
ngrok now returns an information and login page when you try to request an HTML site with a guest account, which broke the tests. Fixed the broken test and added one to specifically test the behaviour.