### PR TITLE
Replaces colors with chalk.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "chai": "^4.3.4",
-        "colors": "^1.4.0",
+        "chalk": "^4.1.2",
         "mocha": "^8.3.2"
       },
       "engines": {
@@ -272,9 +272,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -409,15 +409,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1682,9 +1673,9 @@
       }
     },
     "chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -1790,12 +1781,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "concat-map": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "chai": "^4.3.4",
-    "colors": "^1.4.0",
+    "chalk": "^4.1.2",
     "mocha": "^8.3.2"
   },
   "dependencies": {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,4 @@
-const colors = require("colors/safe");
+const chalk = require("chalk");
 const env = process.env;
 
 // travis master branch sets NGROK_FORCE_TOKENS=true and forces tokens to be present
@@ -12,7 +12,7 @@ if (
 
 if (!env.NGROK_AUTHTOKEN_FREE)
   console.log(
-    colors.yellow(
+    chalk.yellow(
       `Warning: No process.env.NGROK_AUTHTOKEN_FREE found, falling back to shared authtoken.
 Tests may blink if people use it simulatenously.
 For stable test suite, signup at ngrok.com (free) and put your token here.`
@@ -21,7 +21,7 @@ For stable test suite, signup at ngrok.com (free) and put your token here.`
 
 if (!env.NGROK_AUTHTOKEN_PAID)
   console.log(
-    colors.magenta(
+    chalk.magenta(
       "Warning: no process.env.NGROK_AUTHTOKEN_PAID found, skipping related specs"
     )
   );


### PR DESCRIPTION
Turns out that a couple of dependencies were already using chalk themselves, so removing colors will actually slim the development install down a bit.