### PR TITLE
fix: darwin-arm64 download correct binary

### DIFF
--- a/download.js
+++ b/download.js
@@ -39,7 +39,7 @@ function downloadNgrok(callback, options) {
     const cdnFiles = {
       darwinia32: cdn + cdnPath + "darwin-386.zip",
       darwinx64: cdn + cdnPath + "darwin-amd64.zip",
-      darwinarm64: cdn + cdnPath + "darwin-amd64.zip",
+      darwinarm64: cdn + cdnPath + "darwin-arm64.zip",
       linuxarm: cdn + cdnPath + "linux-arm.zip",
       linuxarm64: cdn + cdnPath + "linux-arm64.zip",
       androidarm: cdn + cdnPath + "linux-arm.zip",


### PR DESCRIPTION
I'm currently on an M1 Pro processor and I noticed for my arch (arm64) the postinstall script was downloading an amd64 binary. I tested the change locally and it's now installing the correct file and I'm able to use the npm package. 