### PR TITLE
Throw client errors correctly.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -28,21 +28,26 @@ class NgrokClient {
       }
     } catch (error) {
       let clientError;
-      try {
-        const response = JSON.parse(error.response.body);
-        clientError = new NgrokClientError(
-          response.msg,
-          error.response,
-          response
-        );
-      } catch (e) {
-        clientError = new NgrokClientError(
-          error.response.body,
-          error.response,
-          error.response.body
-        );
+      if (error.response) {
+        try {
+          const response = JSON.parse(error.response.body);
+          clientError = new NgrokClientError(
+            response.msg,
+            error.response,
+            response
+          );
+        } catch (e) {
+          clientError = new NgrokClientError(
+            error.response.body,
+            error.response,
+            error.response.body
+          );
+        }
+        throw clientError;
+      } else {
+        // Rethrow the original error as it is not an HTTP error.
+        throw error;
       }
-      throw clientError;
     }
   }
 


### PR DESCRIPTION
If the HTTP client catches an error but it doesn't have a response, then it is not an HTTP error, so we'll throw the original error instead. This will surface what is causing an error that isn't because of an HTTP response in the client.

Should fix #229, or at least help diagnose it.