### PR TITLE
Including index.d.ts in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "download.js",
     "download.d.ts",
     "index.js",
+    "index.d.ts",
     "ngrok.d.ts",
     "postinstall.js",
     "src/client.js",


### PR DESCRIPTION
Currently index.d.ts is not included in the npm js package,
This should fix it 😄 

`npm publish --dry-run`
 **before**
```cmd
npm notice 
npm notice 📦  ngrok@4.3.2
npm notice === Tarball Contents ===
npm notice 10.5kB README.md
npm notice 51B    bin/ngrok
npm notice 265B   download.d.ts
npm notice 6.3kB  download.js
npm notice 1.8kB  index.js
npm notice 1.3kB  package.json
npm notice 762B   postinstall.js
npm notice 2.5kB  src/client.js
npm notice 4.2kB  src/process.js
npm notice 1.7kB  src/utils.js
npm notice === Tarball Details ===
npm notice name:          ngrok
npm notice version:       4.3.2
npm notice 265B   download.d.ts
npm notice 6.3kB  download.js
npm notice 1.8kB  index.js
npm notice 1.3kB  package.json
npm notice 762B   postinstall.js
npm notice 2.5kB  src/client.js
npm notice 4.2kB  src/process.js
npm notice 1.7kB  src/utils.js
npm notice === Tarball Details ===
npm notice name:          ngrok
npm notice version:       4.3.2
npm notice filename:      ngrok-4.3.2.tgz
npm notice package size:  9.8 kB
npm notice unpacked size: 29.6 kB
npm notice shasum:        ddd3824dc83558e806d1d6abc5d83f0d4428064b
npm notice integrity:     sha512-zq/g3sAVjCNl3[...]1WEd6amnsW5PA==
npm notice total files:   10
```

**after**

```ts
npm notice 📦  ngrok@4.3.2
npm notice === Tarball Contents === 
npm notice 10.5kB README.md     
npm notice 51B    bin/ngrok     
npm notice 265B   download.d.ts 
npm notice 6.3kB  download.js   
npm notice 6.4kB  index.d.ts    
npm notice 1.8kB  index.js      
npm notice 1.3kB  package.json  
npm notice 762B   postinstall.js
npm notice 2.5kB  src/client.js 
npm notice 4.2kB  src/process.js
npm notice 1.7kB  src/utils.js  
npm notice === Tarball Details === 
npm notice name:          ngrok
npm notice version:       4.3.2
npm notice filename:      ngrok-4.3.2.tgz
npm notice package size:  11.2 kB
npm notice unpacked size: 36.0 kB
npm notice shasum:        aac3af580d6e8ba14d1ef30ff118e52325278dbb
npm notice integrity:     sha512-muy/3qZZM7BHL[...]79/uUYzl7WL9A==
npm notice total files:   11
```