### PR TITLE
Allow specifying alternate bin and cache directories when downloading

### DIFF
--- a/download.d.ts
+++ b/download.d.ts
@@ -2,11 +2,13 @@ declare module "ngrok/download" {
   export default function downloadNgrok(
     callback: (err?: Error) => void,
     options?: {
-      cafilePath: string;
-      arch: string;
-      cdnUrl: string;
-      cdnPath: string;
-      ignoreCache: boolean;
+      cafilePath?: string;
+      arch?: string;
+      cdnUrl?: string;
+      cdnPath?: string;
+      ignoreCache?: boolean;
+      cacheDir?: string;
+      binDir?: string;
     }
   ): void;
 }

--- a/download.js
+++ b/download.js
@@ -61,16 +61,20 @@ function downloadNgrok(callback, options) {
 
   function getCacheUrl() {
     let dir;
-    try {
-      dir =
-        os.platform() === "win32" && process.env.APPDATA
-          ? path.join(process.env.APPDATA, "ngrok")
-          : path.join(os.homedir(), ".ngrok");
-      if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
-        fs.mkdirSync(dir);
+
+    if (options.cacheDir) dir = options.cacheDir;
+    else {
+      try {
+        dir =
+          os.platform() === "win32" && process.env.APPDATA
+            ? path.join(process.env.APPDATA, "ngrok")
+            : path.join(os.homedir(), ".ngrok");
+        if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+          fs.mkdirSync(dir);
+        }
+      } catch (err) {
+        dir = path.join(__dirname, "bin");
       }
-    } catch (err) {
-      dir = path.join(__dirname, "bin");
     }
     const name = Buffer.from(cdnUrl).toString("base64");
     return path.join(dir, name + ".zip");
@@ -147,7 +151,7 @@ function downloadNgrok(callback, options) {
 
   function extract(cb) {
     console.error("ngrok - unpacking binary");
-    const moduleBinPath = path.join(__dirname, "bin");
+    const moduleBinPath = options.binDir || path.join(__dirname, "bin");
     extract_zip(cacheUrl, { dir: moduleBinPath })
       .then(() => {
         const suffix = os.platform() === "win32" ? ".exe" : "";

--- a/index.d.ts
+++ b/index.d.ts
@@ -179,7 +179,7 @@ declare module "ngrok" {
       gauge: number;
     }
 
-    interface HTTPRequests extends Metrics {}
+    interface HTTPRequests extends Metrics { }
 
     interface Tunnel {
       name: string;
@@ -203,7 +203,7 @@ declare module "ngrok" {
 
     interface CapturedRequestOptions {
       limit: number;
-      tunnel_name: string;
+      tunnel_name?: string;
     }
 
     interface Request {


### PR DESCRIPTION
I've been using ngrok inside a Lambda function and in that environment, writing to the node_modules directory is not allowed. Instead, I've been using this patch so that I can store download cache and binaries in the temp directory of the OS.

Rather than making the temp directory use explicit, I thought making it configurable would be better