### PR TITLE
Add domain option for tunnel creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ The `bind_tls` option is now `scheme`. When `bind_tls` was true (the default), n
 
 The `auth` option, also available as `httpauth`, is now just `basic_auth`. Note also that the password for `basic_auth` must be between 8 and 128 characters long.
 
+It also makes it possible to use the ngrok free domain which was [introduced in April 2023](https://ngrok.com/blog-post/new-ngrok-domains) by using the `domain` option when creating a tunnel.
+
 ## Upgrading to version 4
 
 The main impetus to update the package was to remove the dependency on the deprecated `request` module. `request` was replaced with `got`. Calls to the main `ngrok` functions, `connect`, `authtoken`, `disconnect`, `kill`, `getVersion` and `getUrl` respond the same as in version 3.

--- a/README.md
+++ b/README.md
@@ -291,7 +291,18 @@ The `bind_tls` option is now `scheme`. When `bind_tls` was true (the default), n
 
 The `auth` option, also available as `httpauth`, is now just `basic_auth`. Note also that the password for `basic_auth` must be between 8 and 128 characters long.
 
-It also makes it possible to use the ngrok free domain which was [introduced in April 2023](https://ngrok.com/blog-post/new-ngrok-domains) by using the `domain` option when creating a tunnel.
+### Using the ngrok static free-domain
+
+In April 2023, ngrok [introduced the ngrok static free-domain](https://ngrok.com/blog-post/new-ngrok-domains), which brings you a static subdomain even for free accounts. To make use of it, just use the `domain` option when creating a tunnel. Example:
+
+```ts
+ngrok.connect({
+  domain: "xxx.ngrok-free.app"
+  authtoken: "YOUR-AUTH-TOKEN"
+})
+```
+
+__Note__: Please make sure to __either__ use the `subdomain` or the `domain` option. Using both would lead to using the subdomain only.  
 
 ## Upgrading to version 4
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,6 +64,7 @@ const tunnelProperties = [
   "key",
   "terminate_at",
   "labels",
+  "domain",
 ];
 
 const globalProperties = [


### PR DESCRIPTION
Since April 2023 it is possible to configure the `domain` option on tunnel creation with the ngrok client, so that you are able to use the free domain (without having to pay for a static subdomain). This merge request makes it possible to use it, otherwise it would just be ignored.

Reference:
https://ngrok.com/blog-post/new-ngrok-domains
https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/ngrok/#flags-12