### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "index.js",
     "index.d.ts",
     "postinstall.js",
-    "src/autthoken.js",
+    "src/authtoken.js",
     "src/client.js",
     "src/config.js",
     "src/constants.js",


### PR DESCRIPTION
A typo in `files` prevents installation from Github. Current version in NPM is version 5.0.0 beta 2 which doesn't incorporate latest patches.