### PR TITLE
Replace equinox.io usage with ngrok.com

### DIFF
--- a/download.js
+++ b/download.js
@@ -31,7 +31,7 @@ function downloadNgrok(callback, options) {
     const arch =
       options.arch || process.env.NGROK_ARCH || os.platform() + os.arch();
     const cdn =
-      options.cdnUrl || process.env.NGROK_CDN_URL || "https://bin.equinox.io";
+      options.cdnUrl || process.env.NGROK_CDN_URL || "https://bin.ngrok.com";
     const cdnPath =
       options.cdnPath ||
       process.env.NGROK_CDN_PATH ||


### PR DESCRIPTION
ngrok is shifting away from using equinox.io for our binary hosting and these URLs now resolve on ngrok.com using the same paths